### PR TITLE
Introduce the "or" Operand for stateno and animno

### DIFF
--- a/trials.lua
+++ b/trials.lua
@@ -2015,11 +2015,11 @@ for row = 1, #main.t_selChars, 1 do
 				end
 			elseif lcline:find("trialstep." .. j .. ".animno") then
 				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].animno = f_str2number(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
-				end
-				for k = 1, #trial[i].trialstep[j].animno, 1 do
-					local temp = trial[i].trialstep[j].animno[k]
-					trial[i].trialstep[j].animno[k] = f_str2number(main.f_strsplit('|', temp))
+					trial[i].trialstep[j].animno = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
+					for k = 1, #trial[i].trialstep[j].animno, 1 do
+						local temp = trial[i].trialstep[j].animno[k]
+						trial[i].trialstep[j].animno[k] = f_str2number(main.f_strsplit('|', temp))
+					end
 				end
 			elseif lcline:find("trialstep." .. j .. ".hitcount") then
 				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then

--- a/trials.lua
+++ b/trials.lua
@@ -1428,7 +1428,7 @@ function start.f_trialsChecker()
 
 		-- Check states and anims; iterate over 'or' operand if multiple states and/or anims are provided
 		statecheck = false
-		local desiredstates = f_str2number(main.f_strsplit('|', start.trials.trial[ct].trialstep[cts].stateno[ctms]))
+		local desiredstates = start.trials.trial[ct].trialstep[cts].stateno[ctms]
 		for k = 1, #desiredstates, 1 do
 			if attackerstate == desiredstates[k] then
 				statecheck = true
@@ -1438,7 +1438,7 @@ function start.f_trialsChecker()
 		animcheck = true
 		if start.trials.trial[ct].trialstep[cts].animno[ctms] ~= nil then
 			animcheck = false
-			local desiredanims = f_str2number(main.f_strsplit('|', start.trials.trial[ct].trialstep[cts].animno[ctms]))
+			local desiredanims = start.trials.trial[ct].trialstep[cts].animno[ctms]
 			for k = 1, #desiredanims, 1 do
 				if attackeranim == desiredanims[k] then
 					animcheck = true
@@ -1996,10 +1996,12 @@ for row = 1, #main.t_selChars, 1 do
 				trial[i].trialstep[j].glyphs = f_trimafterchar(line, "=")
 			elseif lcline:find("trialstep." .. j .. ".stateno") then
 				trial[i].trialstep[j].stateno = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
+				for k = 1, #trial[i].trialstep[j].stateno, 1 do
+					local temp = trial[i].trialstep[j].stateno[k]
+					trial[i].trialstep[j].stateno[k] = f_str2number(main.f_strsplit('|', temp))
+				end
 				trial[i].trialstep[j].numofmicrosteps = #trial[i].trialstep[j].stateno
 				for k = 1, trial[i].trialstep[j].numofmicrosteps, 1 do
-					print(trial[i].trialstep[j].stateno[k])
-
 					trial[i].trialstep[j].stephitscount[k] = 0
 					trial[i].trialstep[j].combocountonstep[k] = 0
 					trial[i].trialstep[j].hitcount[k] = 1
@@ -2014,6 +2016,10 @@ for row = 1, #main.t_selChars, 1 do
 			elseif lcline:find("trialstep." .. j .. ".animno") then
 				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
 					trial[i].trialstep[j].animno = f_str2number(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				end
+				for k = 1, #trial[i].trialstep[j].animno, 1 do
+					local temp = trial[i].trialstep[j].animno[k]
+					trial[i].trialstep[j].animno[k] = f_str2number(main.f_strsplit('|', temp))
 				end
 			elseif lcline:find("trialstep." .. j .. ".hitcount") then
 				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then

--- a/trials.lua
+++ b/trials.lua
@@ -1410,6 +1410,8 @@ function start.f_trialsChecker()
 		local helpercheck = false
 		local projcheck = false
 		local maincharcheck = false
+		local statecheck = false
+		local animcheck = false
 		player(2)
 		local attackerid = gethitvar('id')
 		player(1)
@@ -1427,7 +1429,6 @@ function start.f_trialsChecker()
 		end
 
 		-- Check states and anims; iterate over 'or' operand if multiple states and/or anims are provided
-		statecheck = false
 		local desiredstates = start.trials.trial[ct].trialstep[cts].stateno[ctms]
 		for k = 1, #desiredstates, 1 do
 			if attackerstate == desiredstates[k] then
@@ -1435,7 +1436,6 @@ function start.f_trialsChecker()
 				break
 			end
 		end
-		animcheck = true
 		if start.trials.trial[ct].trialstep[cts].animno[ctms] ~= nil then
 			animcheck = false
 			local desiredanims = start.trials.trial[ct].trialstep[cts].animno[ctms]

--- a/trials.lua
+++ b/trials.lua
@@ -1426,7 +1426,28 @@ function start.f_trialsChecker()
 			-- print("Anim: " .. attackeranim)
 		end
 
-		if (start.trials.trial[ct].trialstep[cts].ishelper[ctms] and start.trials.trial[ct].trialstep[cts].stateno[ctms] == attackerstate) and (attackeranim == start.trials.trial[ct].trialstep[cts].animno[ctms] or start.trials.trial[ct].trialstep[cts].animno[ctms] == nil) then
+		-- Check states and anims; iterate over 'or' operand if multiple states and/or anims are provided
+		statecheck = false
+		local desiredstates = f_str2number(main.f_strsplit('|', start.trials.trial[ct].trialstep[cts].stateno[ctms]))
+		for k = 1, #desiredstates, 1 do
+			if attackerstate == desiredstates[k] then
+				statecheck = true
+				break
+			end
+		end
+		animcheck = true
+		if start.trials.trial[ct].trialstep[cts].animno[ctms] ~= nil then
+			animcheck = false
+			local desiredanims = f_str2number(main.f_strsplit('|', start.trials.trial[ct].trialstep[cts].animno[ctms]))
+			for k = 1, #desiredanims, 1 do
+				if attackeranim == desiredanims[k] then
+					animcheck = true
+					break
+				end
+			end
+		end
+
+		if (start.trials.trial[ct].trialstep[cts].ishelper[ctms] and statecheck) and animcheck then
 			helpercheck = true
 			if start.trials.trial[ct].trialstep[cts].validforvar ~= nil and helpercheck then
 				for i = 1, #start.trials.trial[ct].trialstep[cts].validforvar, 1 do
@@ -1437,7 +1458,7 @@ function start.f_trialsChecker()
 			end
 		end
 
-		if (start.trials.trial[ct].trialstep[cts].isproj[ctms] and start.trials.trial[ct].trialstep[cts].stateno[ctms] == attackerstate) and (attackeranim == start.trials.trial[ct].trialstep[cts].animno[ctms] or start.trials.trial[ct].trialstep[cts].animno[ctms] == nil) then
+		if (start.trials.trial[ct].trialstep[cts].isproj[ctms] and statecheck) and animcheck then
 			projcheck = true
 			if start.trials.trial[ct].trialstep[cts].validforvar ~= nil and projcheck then
 				for i = 1, #start.trials.trial[ct].trialstep[cts].validforvar, 1 do
@@ -1448,7 +1469,7 @@ function start.f_trialsChecker()
 			end
 		end
 
-		maincharcheck = (stateno() == start.trials.trial[ct].trialstep[cts].stateno[ctms] and not(start.trials.trial[ct].trialstep[cts].isproj[ctms]) and not(start.trials.trial[ct].trialstep[cts].ishelper[ctms]) and (anim() == start.trials.trial[ct].trialstep[cts].animno[ctms] or start.trials.trial[ct].trialstep[cts].animno[ctms] == nil) and ((hitpausetime() > 1 and movehit() and combocount() > start.trials.combocounter) or start.trials.trial[ct].trialstep[cts].isthrow[ctms] or start.trials.trial[ct].trialstep[cts].hitcount[ctms] == 0))
+		maincharcheck = (statecheck and not(start.trials.trial[ct].trialstep[cts].isproj[ctms]) and not(start.trials.trial[ct].trialstep[cts].ishelper[ctms]) and animcheck and ((hitpausetime() > 1 and movehit() and combocount() > start.trials.combocounter) or start.trials.trial[ct].trialstep[cts].isthrow[ctms] or start.trials.trial[ct].trialstep[cts].hitcount[ctms] == 0))
 		if start.trials.trial[ct].trialstep[cts].validforvar ~= nil and maincharcheck then
 			for i = 1, #start.trials.trial[ct].trialstep[cts].validforvar, 1 do
 				if maincharcheck then
@@ -1974,9 +1995,11 @@ for row = 1, #main.t_selChars, 1 do
 			elseif lcline:find("trialstep." .. j .. ".glyphs") then
 				trial[i].trialstep[j].glyphs = f_trimafterchar(line, "=")
 			elseif lcline:find("trialstep." .. j .. ".stateno") then
-				trial[i].trialstep[j].stateno = f_str2number(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				trial[i].trialstep[j].stateno = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
 				trial[i].trialstep[j].numofmicrosteps = #trial[i].trialstep[j].stateno
 				for k = 1, trial[i].trialstep[j].numofmicrosteps, 1 do
+					print(trial[i].trialstep[j].stateno[k])
+
 					trial[i].trialstep[j].stephitscount[k] = 0
 					trial[i].trialstep[j].combocountonstep[k] = 0
 					trial[i].trialstep[j].hitcount[k] = 1

--- a/trials.lua
+++ b/trials.lua
@@ -1411,7 +1411,7 @@ function start.f_trialsChecker()
 		local projcheck = false
 		local maincharcheck = false
 		local statecheck = false
-		local animcheck = false
+		local animcheck = true
 		player(2)
 		local attackerid = gethitvar('id')
 		player(1)


### PR DESCRIPTION
This PR introduces the use of the "or" operand for stateno and animno. While this was a relatively straightforward implementation, it presents significant simplification in the way trials can be specified for moves of different strengths that use different state or animation numbers, and for which the trial specification does not matter.

A wiki entry should be produced concurrent to this PR being merged in.