### PR TITLE
Multilanguage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,10 +526,11 @@ trialstep.1.stateno = 1010
 ; trial.guardmode - optional - valid options are none, auto. Defaults to none if unspecified.
 ; trial.dummybuttonjam - optional - valid options are none, a, b, c, x, y, z, start, d, w. Defaults to none if unspecified.
 ; trial.showvarvalpairs - optional - (comma-separated integers, specified in pairs, can specify 0..n pairs). Used to determine whether a trial should be displayed based on the specified variable and value pair(s) in this field. Useful if a trial should only be displayed when character has a specific variable/value pair set, such as being in a specific groove or mode. If specified, the trial will only be displayed if all variable-value pairs return true. These variable-value pairs should only be for the character (not for helpers). Finally, variables can have multiple specified values to test against, which should be separated by the "|" character (e.g. `trial.showforvarvalpairs = 12, 0|2|4` would test var(12) for values 0, 2, and 4).
+; trial.textbox - optional - multilingual - displays specified text in a box specified in the textbox settings in system.def under [Trials Mode]. Supports specification as trial.textbox, or trial.textbox.en, trial.textbox.es, etc. for multilingual support. Will default to trial.textbox.en (or trial.textbox) if selected language cannot be matched.
 
 ; dummymode, guardmode, and dummybuttonjam are defined once per trial. The other parameters can be defined for each trial step - notice the syntax, where X is the trial number.
 
-; trialstep.X.text - optional - (string). Text for trial step (only displayed in vertical trials layout).
+; trialstep.X.text - optional - multilingual - (string). Text for trial step (only displayed in vertical trials layout). Supports specification as trialstep.X.text, or trialstep.X.text.en, trialstep.X.text.es, etc. for multilingual support. Will default to trialstep.X.text.en (or trialstep.X.text) if selected language cannot be matched.
 ; trialstep.X.glyphs - optional - (string, see Glyph documentation [https://github.com/ikemen-engine/Ikemen-GO/wiki/Miscellaneous-info#movelists] for syntax). Same syntax as movelist glyphs. Glyphs are displayed in vertical and horizontal trials layouts.
 ; trialstep.X.stateno - mandatory - (integer or comma-separated integers). State to be checked to pass trial. This is the state whether it's the main character, a helper, or even a projectile.
 
@@ -553,7 +554,11 @@ trialstep.1.isthrow = true
 ;---------------------------------------------
 
 [TrialDef, Kung Fu Taunt]
-trialstep.1.text = Kung Fu Taunt
+trial.textbox.en = This is an English textbox!
+trial.textbox.es = Este es un cuadro de texto en español.
+
+trialstep.1.text.en = Kung Fu Taunt
+trialstep.1.text.es = Kung Fu Pulla
 trialstep.1.glyphs = ^S
 trialstep.1.stateno = 195
 trialstep.1.hitcount = 0

--- a/README.md
+++ b/README.md
@@ -35,24 +35,9 @@ If you are using `trials.sff`, make sure you point to it in the system.def's [Fi
 
 The universal trials mode supports **vertical** trials readouts, and **horizontal** readouts as seen in KOF XIV, among other games. 
 The sample `system.def` included in this file can be configured to support either or both layouts, but shared in this readme, it should work "out of the box" with the `mugen1` screenpack found [here](https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack). 
-Below you'll find a brief summary of screenpack features supported by trials mode. For more detail, please consult the example `system.def` templates provided in this file for both vertical and horizontal layouts.
-
-You can make the trials mode look as fancy or as basic as you want. 
-The `system.def` trials mode example included in this readme only leverage "stock" Ikemen fonts and sprites in the most minimal way possible.
-
-- A window must be specified in which the trial steps are drawn. This feature enables long trial lists that need to scroll (for vertical layouts) or have line returns and potentially scrolling (for horizontal layouts).
-- The trial title name can optionally be displayed. Text and two background elements (bg and front) can be specified.
-- Trial steps come in three flavors: Upcoming, Current, and Completed. Text and background elements can be specified for each type. 
-	- For horizontal layouts, the background elements are handled differently. Background elements are tiled dynamically to fit the width and height of the glyphs and desired padding around the glyph for that step. Each trial step type has "tail" and a "head" that sandwiches the main background element. Tail, head, and background elements are specified for Upcoming, Current, and Completed steps. Note that trial step text is not displayed in horizontal layouts.
-	- palFX can be specified for Upcoming, Current, and Completed steps, as well as for the displayed glyphs associated with each step type.
-- A static or animated background can be displayed for all trial steps. This background is independent of all trial step backgrounds, and is only displayed when a trial is active.
-- Glyphs can be automatically scaled according to the font used (especially useful for vertical layouts).
-	- Glyphs are optional for vertical layouts, but they are mandatory for horizontal layouts as text is not displayed in horizontal layouts. Trials definition files with missing glyphs will crash horizontal layouts.
-- For Success and All Clear events, text and sound elements, as well as two background elements (bg and front) can be specified.
-- Two timers are available: one keeps track of the entire time spent on the trials, while the other keeps track of the time spent on the current trial. Display of the timers is optional. Utilization of the various pause menu functions (such as skipping to the nex trial) will void the total timer, for instance.
-- A text string that shows the current trial can optionally be displayed.
-- Other features:
-	- The user can choose to apply palFX in the Trials Select Screen to portraits of characters who do not have trials definition files.
+Below you'll find a brief summary of screenpack features supported by trials mode. 
+For more detail, please consult the example `system.def` templates provided in this file for both vertical and horizontal layouts.
+The [Trials Mode wiki](https://github.com/two4teezee/Ikemen-GO-Trials-Mode/wiki) goes into great depth on all supported features.
 
 ## system.def Example
 
@@ -341,7 +326,7 @@ glyphs.horizontal.spacing = 0,0
 ; totaltrialtimer shows the total time for the trial. It is erased if the pause menu is used to skip or rewind.
 ; currenttrialtimer shows the time spent on the current trial attempt.
 ; --------------------------------------------------------------------------
-trialcounter.pos = 10,710
+trialcounter.pos = 10,690
 trialcounter.font = 1,0,1
 trialcounter.scale = 2,2
 ; trialcounter.font.height	=
@@ -358,6 +343,17 @@ currenttrialtimer.font = 1,0,-1
 currenttrialtimer.scale = 2,2
 ; currenttrialtimer.font.height	=
 currenttrialtimer.text = "Current Trial: %s"
+
+; TRIAL RESET REMINDER AND SWITCH ------------------------------------------
+; trialresetenabled allows the user to reset the player and dummy position to center stage (or specified trials position) when the d and w keys are pressed simultaneously
+; trialresetreminder displays a string that reminds the player they can reset the trial position with the specified key input
+; --------------------------------------------------------------------------
+trialresetenabled = true
+trialresetreminder.pos = 10,710
+trialresetreminder.font = 1,0,1
+trialresetreminder.scale = 2,2
+; trialresetreminder.font.height	=
+trialresetreminder.text = "Hit d + w to reset position"
 
 ; TRIALS TEXT BOX ----------------------------------------------------------
 ; A textbox can accompany each trial if it is specified within the trials definition file.
@@ -501,8 +497,11 @@ A sample `trials.def` for kfmZ is provided below. The trials are presented to th
 trial.dummymode = stand
 trial.guardmode = none
 trial.dummybuttonjam = none
+; trial.dummylife =
+; trial.playerlife =
+; trial.dummypos =
+; trial.playerpos =
 ; trial.showforvarvalpairs = 
-
 ; trial.textbox = This is KFM's first trial. Good luck!
 
 trialstep.1.text = Strong Kung Fu Palm
@@ -525,10 +524,14 @@ trialstep.1.stateno = 1010
 ; trial.dummymode - optional - valid options are stand (default), crouch, jump, wjump. Defaults to stand if unspecified.
 ; trial.guardmode - optional - valid options are none, auto. Defaults to none if unspecified.
 ; trial.dummybuttonjam - optional - valid options are none, a, b, c, x, y, z, start, d, w. Defaults to none if unspecified.
+; trial.dummylife - optional - sets the dummy's life total.
+; trial.playerlife - optional - sets the player's life total. Useful for trials that involve desparation moves or require a specific life state.
+; trial.dummypos - optional - sets the dummy's position on the stage. Valid options are left-corner, right-corner, far, medium, close. If enabled, the player can reset positioning according to this information by hitting the d and w keys simultaneously. Defaults to center stage.
+; trial.playerpos - optional - sets the player's position on the stage. Valid options are left-corner, right-corner, far, medium, close. If enabled, the player can reset positioning according to this information by hitting the d and w keys simultaneously. Defaults to center stage.
 ; trial.showvarvalpairs - optional - (comma-separated integers, specified in pairs, can specify 0..n pairs). Used to determine whether a trial should be displayed based on the specified variable and value pair(s) in this field. Useful if a trial should only be displayed when character has a specific variable/value pair set, such as being in a specific groove or mode. If specified, the trial will only be displayed if all variable-value pairs return true. These variable-value pairs should only be for the character (not for helpers). Finally, variables can have multiple specified values to test against, which should be separated by the "|" character (e.g. `trial.showforvarvalpairs = 12, 0|2|4` would test var(12) for values 0, 2, and 4).
 ; trial.textbox - optional - multilingual - displays specified text in a box specified in the textbox settings in system.def under [Trials Mode]. Supports specification as trial.textbox, or trial.textbox.en, trial.textbox.es, etc. for multilingual support. Will default to trial.textbox.en (or trial.textbox) if selected language cannot be matched.
 
-; dummymode, guardmode, and dummybuttonjam are defined once per trial. The other parameters can be defined for each trial step - notice the syntax, where X is the trial number.
+; The options above are defined once per trial. The other parameters can be defined for each trial step - notice the syntax, where X is the trial number.
 
 ; trialstep.X.text - optional - multilingual - (string). Text for trial step (only displayed in vertical trials layout). Supports specification as trialstep.X.text, or trialstep.X.text.en, trialstep.X.text.es, etc. for multilingual support. Will default to trialstep.X.text.en (or trialstep.X.text) if selected language cannot be matched.
 ; trialstep.X.glyphs - optional - (string, see Glyph documentation [https://github.com/ikemen-engine/Ikemen-GO/wiki/Miscellaneous-info#movelists] for syntax). Same syntax as movelist glyphs. Glyphs are displayed in vertical and horizontal trials layouts.
@@ -603,6 +606,9 @@ trialstep.1.stateno = 1000|1010
 ;---------------------------------------------
 
 [TrialDef, Kung Fu Juggle Combo]
+; In this trial, the position for the dummy on the stage is set. The player can reset positioning by hitting d + w.
+trial.dummypos = right-corner 
+
 trialstep.1.text = Kung Fu Knee and Extra Kick
 trialstep.1.glyphs = _F_F_+^K_.^K
 trialstep.1.stateno = 1060, 1055
@@ -676,5 +682,5 @@ Trials Mode ships with the several pause menu options. Customizing the pause men
 - **Previous Trial**: return to the previous trial
 - **Trials List**: view a list of the trials, and select which one to activate
 - **Trial Advancement**: toggles between either Auto-Advance or Repeat, allows the player to play a single trial on repeat if desired
-- **Reset on Success**: resets the players to center stage when the trial is cleared. This can be set in the `system.def`, but the player can modify it in-game as well.
+- **Reset on Success**: resets the players to center stage when the trial is cleared. This can be set in the `system.def`, but the player can modify it in-game as well. If dummy and/or player positions are specified, the dummy and player will be moved accordingly.
 - **Trials Layout**: toggles between Vertical and Horizontal trials layout. This can be set in the `system.def`, but the player can modify it in-game as well.

--- a/trials.lua
+++ b/trials.lua
@@ -1962,9 +1962,9 @@ for row = 1, #main.t_selChars, 1 do
 						showforvar = {nil},
 						showforval = {nil},
 						elapsedtime = 0,
-						textbox = "",
 						textcnt = 0,
 						starttick = roundtime()+1,
+						lang = gameOption('Config.Language'):lower(),
 						trialstep = {},
 					}
 					temp = {}
@@ -1981,6 +1981,19 @@ for row = 1, #main.t_selChars, 1 do
 			elseif lcline:find("dummybuttonjam") then
 				trial[i].buttonjam = f_trimafterchar(lcline, "=")
 			elseif lcline:find("showforvarvalpairs") then
+-- 				local text = "hello.world.en"
+
+-- -- This will match "hello" because it's a partial match at the beginning
+-- local partial_match = string.match(text, "hello")
+-- print(partial_match) -- Output: hello
+
+-- -- This will *not* match because "hello" is not the full string
+-- local full_string_no_match = string.match(text, "^hello$")
+-- print(full_string_no_match) -- Output: nil
+
+-- -- This will match because the entire string "hello world" matches the pattern
+-- local full_string_match = string.match(text, "^hello.world.en$")
+-- print(full_string_match) -- Output: hello world
 				temp = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
 				trial[i].showforvar = {}
 				trial[i].showforval = {}
@@ -1988,8 +2001,16 @@ for row = 1, #main.t_selChars, 1 do
 					trial[i].showforvar[#trial[i].showforvar+1] = tonumber(temp[k])
 					trial[i].showforval[#trial[i].showforval+1] = f_str2number(main.f_strsplit('|', temp[k+1]))
 				end
-			elseif lcline:find("textbox") then
+			elseif lcline:find("textbox." .. trial[i].lang) and not trial[i].langfound then
 				trial[i].textbox = f_trimafterchar(lcline, "=")
+				trial[i].langfound = true
+				if lcline:find("textbox." .. trial[i].lang) then
+					trial[i].textbox = f_trimafterchar(lcline, "=")
+				elseif lcline:find("textbox.en") then
+					trial[i].textbox = f_trimafterchar(lcline, "=")
+				elseif lcline:find("textbox") then
+					trial[i].textbox = f_trimafterchar(lcline, "=")
+				end
 			elseif lcline:find("trialstep." .. j .. ".text") then
 				trial[i].trialstep[j].text = f_trimafterchar(line, "=")
 			elseif lcline:find("trialstep." .. j .. ".glyphs") then

--- a/trials.lua
+++ b/trials.lua
@@ -395,6 +395,12 @@ local t_base = {
     currenttrialtimer_scale = {1.0, 1.0},
     currenttrialtimer_font_height = -1,
     currenttrialtimer_text = '',
+	trialresetenabled = "true",
+    trialresetreminder_pos = {0,0},
+    trialresetreminder_font = {'f-6x9.def', 0, 0, 255, 255, 255, -1},
+    trialresetreminder_scale = {1.0, 1.0},
+    trialresetreminder_font_height = -1,
+    trialresetreminder_text = '',
     success_pos = {0, 0},
     success_snd = {-1, 0},
     success_bg_anim = -1,
@@ -928,6 +934,7 @@ function start.f_trialsBuilder()
 		trialcounter = main.f_createTextImg(motif.trials_mode, 'trialcounter'),
 		totaltrialtimer = main.f_createTextImg(motif.trials_mode, 'totaltrialtimer'),
 		currenttrialtimer = main.f_createTextImg(motif.trials_mode, 'currenttrialtimer'),
+		trialresetreminder = main.f_createTextImg(motif.trials_mode, 'trialresetreminder'),
 	}
 	start.trials.draw.textbox_title:update({x = motif.trials_mode.textbox_pos[1]+motif.trials_mode.textbox_title_offset[1], y = motif.trials_mode.textbox_pos[2]+motif.trials_mode.textbox_title_offset[1],})
 	start.trials.draw.textbox_text:update({x = motif.trials_mode.textbox_pos[1]+motif.trials_mode.textbox_text_offset[1]+motif.trials_mode.textbox_text_window[1], y = motif.trials_mode.textbox_pos[2]+motif.trials_mode.textbox_text_offset[2]+motif.trials_mode.textbox_text_window[2],})
@@ -936,6 +943,7 @@ function start.f_trialsBuilder()
 	start.trials.draw.trialcounter:update({x = motif.trials_mode.trialcounter_pos[1], y = motif.trials_mode.trialcounter_pos[2],})
 	start.trials.draw.totaltrialtimer:update({x = motif.trials_mode.totaltrialtimer_pos[1], y = motif.trials_mode.totaltrialtimer_pos[2],})
 	start.trials.draw.currenttrialtimer:update({x = motif.trials_mode.currenttrialtimer_pos[1], y = motif.trials_mode.currenttrialtimer_pos[2],})
+	start.trials.draw.trialresetreminder:update({x = motif.trials_mode.trialresetreminder_pos[1], y = motif.trials_mode.trialresetreminder_pos[2], text = motif.trials_mode.trialresetreminder_text})
 	for _, v in ipairs({'vertical','horizontal'}) do
 		start.trials.draw[v] = {
 			upcomingtextline = {},
@@ -1087,6 +1095,12 @@ function start.f_trialsDrawer()
 			else
 				--start.trials.draw.currenttrialtimer:update({text = "Timer Disabled"})
 				--start.trials.draw.currenttrialtimer:draw()
+			end
+
+			-- Draw trial reset reminder if enabled
+			if motif.trials_mode.trialresetenabled == "true" then
+				--start.trials.draw.trialresetreminder:update({text = motif.trials_mode.trialresetreminder_text})
+				start.trials.draw.trialresetreminder:draw()
 			end
 
 			-- Draw trialsteps bg overlay if enabled
@@ -1603,7 +1617,7 @@ function start.f_trialsChecker()
 			end
 			player(1)
 		end
-	elseif inputtime('d') > 0 and inputtime('w') > 0 and start.trials.draw.fade == 0 then
+	elseif inputtime('d') > 0 and inputtime('w') > 0 and start.trials.draw.fade == 0 and motif.trials_mode.trialresetenabled == "true" then
 		start.trials.draw.fadein = motif.trials_mode.fadein_time
 		start.trials.draw.fadeout = motif.trials_mode.fadeout_time
 		start.trials.draw.fade = start.trials.draw.fadein + start.trials.draw.fadeout
@@ -1642,82 +1656,61 @@ end
 
 function start.f_trialsFade()
 	local stagelocalcoordX = stagevar("stageinfo.localcoord.x")
-	local stagelocalcoordY = stagevar("stageinfo.localcoord.y")
 	local stageboundleft = stagevar("bound.screenleft")
 	local stageboundright = stagevar("bound.screenright")
-
 	local dummyposx = stagevar("playerinfo.p2startx") / (stagelocalcoordX/320)
 	local dummyposy = stagevar("playerinfo.p2starty") / (stagelocalcoordX/320)
 	local playerposx = stagevar("playerinfo.p1startx") / (stagelocalcoordX/320)
 	local playerposy = stagevar("playerinfo.p1starty") / (stagelocalcoordX/320)
-
 	local leftbound = stagevar("camera.boundleft")
 	local rightbound = stagevar("camera.boundright")
-
 	local cameraPosX = 0
-	local p1facing = 1
-	local p2facing = -1
+	local posx = 0
+	local oppx = 0
 
-	player(2)
-	local p2posx = posX()
-	player(2)
-	local p2posy = posY()
-	local p1posx = posX()
-	local p1posy = posY()
-
-    if start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
+	if start.trials.trial[start.trials.currenttrial].dummypos == 'left-corner' or start.trials.trial[start.trials.currenttrial].playerpos == 'left-corner' then
+		cameraPosX = leftbound / (stagelocalcoordX/320)
+		posx = - (stagelocalcoordX/2 - stageboundleft) / (stagelocalcoordX/320)
+		if start.trials.trial[start.trials.currenttrial].dummypos == 'close' or start.trials.trial[start.trials.currenttrial].playerpos == 'close' then
+			oppx = posx + 10
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' or start.trials.trial[start.trials.currenttrial].playerpos == 'far' then
+			oppx = posx + 260
+		else --medium or nil
+			oppx = posx + 130
+		end
 		if start.trials.trial[start.trials.currenttrial].dummypos == 'left-corner' then
-			dummyposx = -(stagelocalcoordX/2 - stageboundleft) / (stagelocalcoordX/320)
-			p1facing = -1
-			p2facing = 1
-			cameraPosX = leftbound / (stagelocalcoordX/320)
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'right-corner' then
-			dummyposx = (stagelocalcoordX/2 - stageboundright) / (stagelocalcoordX/320)
-			cameraPosX = rightbound / (stagelocalcoordX/320)
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'close' then
-			dummyposx = p2posx + 10 * p1facing
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' then
-			dummyposx = p2posx + 130 * p1facing
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' then
-			dummyposx = p2posx + 260 * p1facing
+			dummyposx = posx
+			playerposx = oppx
+		else
+			playerposx = posx
+			dummyposx = oppx
 		end
-	end
-	if start.trials.trial[start.trials.currenttrial].playerpos ~= nil then
-		if start.trials.trial[start.trials.currenttrial].playerpos == 'left-corner' then
-			playerposx = -(stagelocalcoordX/2 - stageboundleft) / (stagelocalcoordX/320)
-			p1facing = -1
-			p2facing = 1
-			cameraPosX = leftbound / (stagelocalcoordX/320)
-			if start.trials.trial[start.trials.currenttrial].dummypos == 'close' then
-				dummyposx = playerposx + 10 * p1facing
-			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' then
-				dummyposx = playerposx + 130 * p1facing
-			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' then
-				dummyposx = playerposx + 260 * p1facing
-			else
-				dummyposx = playerposx + 130 * p1facing
-			end
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'right-corner' then
-			playerposx = (stagelocalcoordX/2 - stageboundright) / (stagelocalcoordX/320)
-			cameraPosX = rightbound / (stagelocalcoordX/320)
-			if start.trials.trial[start.trials.currenttrial].dummypos == 'close' then
-				dummyposx = playerposx - 10 * p1facing
-			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' then
-				dummyposx = playerposx - 130 * p1facing
-			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' then
-				dummyposx = playerposx - 260 * p1facing
-			else
-				dummyposx = playerposx - 130 * p1facing
-			end
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'close' then
-			playerposx = dummyposx + 10 * p2facing
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'medium' then
-			playerposx = dummyposx + 130 * p2facing
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'far' then
-			playerposx = dummyposx + 260 * p2facing
+	elseif start.trials.trial[start.trials.currenttrial].dummypos == 'right-corner' or start.trials.trial[start.trials.currenttrial].playerpos == 'right-corner' then
+		cameraPosX = rightbound / (stagelocalcoordX/320)
+		posx = (stagelocalcoordX/2 - stageboundright) / (stagelocalcoordX/320)
+		if start.trials.trial[start.trials.currenttrial].dummypos == 'close' or start.trials.trial[start.trials.currenttrial].playerpos == 'close' then
+			oppx = posx - 10
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' or start.trials.trial[start.trials.currenttrial].playerpos == 'far' then
+			oppx = posx - 260
+		else --medium or nil
+			oppx = posx - 130
 		end
-	elseif start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
-		playerposx = dummyposx + 130 * p2facing
+		if start.trials.trial[start.trials.currenttrial].dummypos == 'right-corner' then
+			dummyposx = posx
+			playerposx = oppx
+		else
+			playerposx = posx
+			dummyposx = oppx
+		end
+	elseif start.trials.trial[start.trials.currenttrial].dummypos == 'close' or start.trials.trial[start.trials.currenttrial].playerpos == 'close' then
+		dummyposx = 5
+		playerposx = -5
+	elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' or start.trials.trial[start.trials.currenttrial].playerpos == 'medium' then
+		dummyposx = 65
+		playerposx = -65
+	elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' or start.trials.trial[start.trials.currenttrial].playerpos == 'far' then
+		dummyposx = 130
+		playerposx = -130
 	end
 
 	mapSet('_iksys_trialsCameraPosX', cameraPosX)
@@ -2114,9 +2107,9 @@ for row = 1, #main.t_selChars, 1 do
 				trial[i].guardmode = f_trimforchar(lcline, "=", "after")
 			elseif lcline:find("dummybuttonjam") then
 				trial[i].buttonjam = f_trimforchar(lcline, "=", "after")
-			elseif lcline:find("p1life") then
+			elseif lcline:find("playerlife") then
 				trial[i].p1life = tonumber(f_trimforchar(lcline, "=", "after"))
-			elseif lcline:find("p2life") then
+			elseif lcline:find("dummylife") then
 				trial[i].p2life = tonumber(f_trimforchar(lcline, "=", "after"))
 			elseif lcline:find("playerpos") then
 				trial[i].playerpos = f_trimforchar(lcline, "=", "after")

--- a/trials.lua
+++ b/trials.lua
@@ -1633,12 +1633,10 @@ function start.f_trialsSuccess(successstring, index)
 end
 
 function start.f_trialsFade()
-	player(2)
-	local dummyposx = posX()
-	local dummyposy = posY()
-	player(1)
-	local playerposx = posX()
-	local playerposy = posY()
+	local dummyposx = stagevar("playerinfo.p2startx")
+	local dummyposy = stagevar("playerinfo.p2starty")
+	local playerposx = stagevar("playerinfo.p1startx")
+	local playerposy = stagevar("playerinfo.p1starty")
 
     if start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
 		player(2)
@@ -1654,9 +1652,6 @@ function start.f_trialsFade()
 			dummyposx = posX() + const240p(260)*-facing()
 		end
 		player(1)
-		mapSet('_iksys_trialsDummyPosX', dummyposx)
-	else
-		mapSet('_iksys_trialsDummyPosX', stagevar("playerinfo.p2startx"))
 	end
 
 	if start.trials.trial[start.trials.currenttrial].playerpos ~= nil then
@@ -1671,12 +1666,15 @@ function start.f_trialsFade()
 		elseif start.trials.trial[start.trials.currenttrial].playerpos == "far" then
 			playerposx = posX() + const240p(260)*-facing()
 		end
-		mapSet('_iksys_trialsPlayerPosX', playerposx)
 	elseif start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
-		mapSet('_iksys_trialsPlayerPosX', dummyposx + const240p(130) * -facing())
-	else
-		mapSet('_iksys_trialsPlayerPosX', stagevar("playerinfo.p1startx"))
+		playerpox = dummyposx + const240p(130) * -facing()
 	end
+	print("dummyposX = " .. dummyposx .. ", playerposX = " .. playerposx)
+	mapSet('_iksys_trialsDummyPosX', dummyposx)
+	mapSet('_iksys_trialsDummyPosY', dummyposy)
+	-- mapSet('_iksys_trialsPlayerPosX', playerposx)
+	mapSet('_iksys_trialsPlayerPosX', dummyposx)
+	mapSet('_iksys_trialsPlayerPosY', playerposy)
 	
 	-- This function is responsible for fadein/fadeout if trialsresetonsuccess is set to true.
 	if start.trials.draw.fadeout > 0 then

--- a/trials.lua
+++ b/trials.lua
@@ -134,13 +134,13 @@ local t_base = {
     trialslayout = "vertical",
 	trialsteps_vertical_pos = {0, 0},
     trialsteps_vertical_spacing = {0, 0},
-    trialsteps_vertical_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
-	trialsteps_vertical_window_withtextbox = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+    trialsteps_vertical_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
+	trialsteps_vertical_window_withtextbox = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 	trialsteps_horizontal_pos = {0, 0},
     trialsteps_horizontal_spacing = {0, 0},
 	trialsteps_horizontal_padding = 0,
-    trialsteps_horizontal_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
-	trialsteps_horizontal_window_withtextbox = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+    trialsteps_horizontal_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
+	trialsteps_horizontal_window_withtextbox = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 	trialsteps_vertical_bg_anim = -1,
     trialsteps_vertical_bg_spr = {},
     trialsteps_vertical_bg_offset = {0, 0},
@@ -148,8 +148,8 @@ local t_base = {
     trialsteps_vertical_bg_scale = {1.0, 1.0},
     trialsteps_vertical_bg_displaytime = 0,
 	-- trialsteps_vertical_bg_overlay_visible = "false",
-	-- trialsteps_vertical_bg_overlay_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
-	-- trialsteps_vertical_bg_overlay_window_withtextbox = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+	-- trialsteps_vertical_bg_overlay_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
+	-- trialsteps_vertical_bg_overlay_window_withtextbox = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 	-- trialsteps_vertical_bg_overlay_col = {0, 0, 0},
 	-- trialsteps_vertical_bg_overlay_alpha = {0, 128},
 	trialsteps_horizontal_bg_anim = -1,
@@ -159,8 +159,8 @@ local t_base = {
     trialsteps_horizontal_bg_scale = {1.0, 1.0},
     trialsteps_horizontal_bg_displaytime = 0,
 	-- trialsteps_horizontal_bg_overlay_visible = "false",
-	-- trialsteps_horizontal_bg_overlay_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
-	-- trialsteps_horizontal_bg_overlay_window_withtextbox = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+	-- trialsteps_horizontal_bg_overlay_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
+	-- trialsteps_horizontal_bg_overlay_window_withtextbox = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 	-- trialsteps_horizontal_bg_overlay_col = {0, 0, 0},
 	-- trialsteps_horizontal_bg_overlay_alpha = {0, 128},
 	selscreenpalfx_add = {},
@@ -442,7 +442,7 @@ local t_base = {
 	textbox_title_text = '',
 	textbox_title_font_height = -1,
 	textbox_title_scale = {1.0, 1.0},
-	textbox_text_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+	textbox_text_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 	textbox_text_offset = {0,0},
 	textbox_text_font = {'f-6x9.def', 0, 0, 255, 255, 255, -1},
 	textbox_text_text = '',
@@ -456,7 +456,7 @@ local t_base = {
 	textbox_bg_scale = {1.0, 1.0},
 	textbox_bg_displaytime = -1,
 	textbox_overlay_visible = "false",
-	textbox_overlay_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+	textbox_overlay_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 	textbox_overlay_col = {0, 0, 0},
 	textbox_overlay_alpha = {0, 128},
 	textbox_front_anim = -1,
@@ -470,7 +470,7 @@ local t_base = {
 	textbox_portrait_offset = {0, 0},
 	textbox_portrait_facing = 1,
 	textbox_portrait_scale = {1.0, 1.0},
-	textbox_portrait_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]},
+	textbox_portrait_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)},
 }
 
 -- Merge trials data into table
@@ -532,7 +532,7 @@ local t_base_info = {
 	menu_arrow_down_facing = 1, --Ikemen feature
 	menu_arrow_down_scale = {1.0, 1.0}, --Ikemen feature
 	menu_title_uppercase = 1, --Ikemen feature
-	overlay_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]}, --Ikemen feature (0, 0, 320, 240)
+	overlay_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)}, --Ikemen feature (0, 0, 320, 240)
 	overlay_col = {0, 0, 0}, --Ikemen feature
 	overlay_alpha = {0, 128}, --Ikemen feature
 	cursor_move_snd = {100, 0}, --Ikemen feature
@@ -556,7 +556,7 @@ local t_base_info = {
 	movelist_window_width = 300, --Ikemen feature
 	movelist_window_margins_y = {20, 1}, --Ikemen feature
 	movelist_window_visibleitems = 18, --Ikemen feature
-	movelist_overlay_window = {0, 0, main.SP_Localcoord[1], main.SP_Localcoord[2]}, --Ikemen feature (0, 0, 320, 240)
+	movelist_overlay_window = {0, 0, motifLocalcoord(0), motifLocalcoord(1)}, --Ikemen feature (0, 0, 320, 240)	
 	movelist_overlay_col = {0, 0, 0}, --Ikemen feature
 	movelist_overlay_alpha = {0, 128}, --Ikemen feature
 	movelist_arrow_up_anim = -1, --Ikemen feature
@@ -919,6 +919,7 @@ function start.f_trialsBuilder()
 		fade = 0,
 		fadein = 0,
 		fadeout = 0,
+		fadetriggered = false,
 		textbox_text = main.f_createTextImg(motif.trials_mode, 'textbox_text'),
 		textbox_title = main.f_createTextImg(motif.trials_mode, 'textbox_title'),
 		success_text = main.f_createTextImg(motif.trials_mode, 'success_text'),
@@ -1592,7 +1593,7 @@ function start.f_trialsChecker()
 	--If the trial was completed successfully, draw the trials success
 	if start.trials.draw.success > 0 then
 		start.f_trialsSuccess('success', ct)
-	elseif start.trials.draw.fade > 0 and motif.trials_mode.trialsresetonsuccess == "true" then
+	elseif start.trials.draw.fade > 0 and (motif.trials_mode.trialsresetonsuccess == "true" or start.trials.draw.fadetriggered) then
 		if start.trials.draw.fade < start.trials.draw.fadein + start.trials.draw.fadeout then
 			start.f_trialsFade()
 		else
@@ -1602,6 +1603,13 @@ function start.f_trialsChecker()
 			end
 			player(1)
 		end
+	elseif inputtime('d') > 0 and inputtime('w') > 0 and start.trials.draw.fade == 0 then
+		start.trials.draw.fadein = motif.trials_mode.fadein_time
+		start.trials.draw.fadeout = motif.trials_mode.fadeout_time
+		start.trials.draw.fade = start.trials.draw.fadein + start.trials.draw.fadeout
+		start.trials.draw.fadetriggered = true
+	else
+		start.trials.draw.fadetriggered = false
 	end
 end
 
@@ -1656,8 +1664,6 @@ function start.f_trialsFade()
 	local p2posy = posY()
 	local p1posx = posX()
 	local p1posy = posY()
-	local currentCameraPosX = cameraposX()
-	local currentCameraPosY = cameraposY()
 
     if start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
 		if start.trials.trial[start.trials.currenttrial].dummypos == 'left-corner' then
@@ -1730,7 +1736,6 @@ function start.f_trialsFade()
 	elseif start.trials.draw.fadein > 0 then
 		if main.fadeType == 'fadeout' then
 			mapSet('_iksys_trialsReposition', 1)
-			print("flag set, ct = " .. start.trials.currenttrial)
 			main.f_fadeReset('fadein',motif.trials_mode)
 		elseif main.fadeType == 'fadein' then
 			mapSet('_iksys_trialsCameraReset', 1)

--- a/trials.lua
+++ b/trials.lua
@@ -39,26 +39,16 @@ local function f_timeConvert(value)
 	return m, s, x
 end
 
-local function f_trimafterchar(line, char)
-	-- trims a string after a specified character.
+local function f_trimforchar(line, char, when)
+	-- trims a string before or after a specified character.
 	-- also trims leading and trailing whitespace
 	x = string.find(line, char)
 	if x ~= nil then
-		line = string.sub(line, x+1, #line)
-		line = string.gsub(line, '^%s*(.-)%s*$', '%1')
-		line = string.gsub(line, '[ \t]+%f[\r\n%z]', '')
-	else
-		line = ""
-	end
-	return line
-end
-
-local function f_trimbeforechar(line, char)
-	-- trims a string before a specified character.
-	-- also trims leading and trailing whitespace
-	x = string.find(line, char)
-	if x ~= nil then
-		line = string.sub(line, 1, x-1)
+		if when == "after" then
+			line = string.sub(line, x+1, #line)
+		elseif when == "before" then
+			line = string.sub(line, 1, x-1)
+		end
 		line = string.gsub(line, '^%s*(.-)%s*$', '%1')
 		line = string.gsub(line, '[ \t]+%f[\r\n%z]', '')
 	else
@@ -1906,7 +1896,7 @@ for row = 1, #main.t_selChars, 1 do
 			line = line:gsub('%s*;.*$', '')
 			lcline = string.lower(line)
 			if lcline:match('trials') then
-				main.t_selChars[row].trialsdef = main.t_selChars[row].dir .. f_trimafterchar(line, "=")
+				main.t_selChars[row].trialsdef = main.t_selChars[row].dir .. f_trimforchar(line, "=", "after")
 				break
 			end
 		end
@@ -1985,21 +1975,21 @@ for row = 1, #main.t_selChars, 1 do
 						trialstep = {},
 					}
 					temp = {}
-					line = f_trimafterchar(line, ",")
+					line = f_trimforchar(line, ",", "after")
 					if line == "" then
 						line = "Trial " .. tostring(i)
 					end
 					trial[i].name = line
 				end
 			elseif lcline:find("dummymode") then
-				trial[i].dummymode = f_trimafterchar(lcline, "=")
+				trial[i].dummymode = f_trimforchar(lcline, "=", "after")
 			elseif lcline:find("guardmode") then
-				trial[i].guardmode = f_trimafterchar(lcline, "=")
+				trial[i].guardmode = f_trimforchar(lcline, "=", "after")
 			elseif lcline:find("dummybuttonjam") then
-				trial[i].buttonjam = f_trimafterchar(lcline, "=")
+				trial[i].buttonjam = f_trimforchar(lcline, "=", "after")
 			elseif lcline:find("showforvarvalpairs") then
 				showforvarvalpairsfound = false
-				temp = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
+				temp = main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", ""))
 				trial[i].showforvar = {}
 				trial[i].showforval = {}
 				for k = 1, #temp, 2 do
@@ -2008,29 +1998,29 @@ for row = 1, #main.t_selChars, 1 do
 				end
 			elseif lcline:find("textbox") and not triallangfound then
 				if lcline:find("textbox." .. lang) then
-					trial[i].textbox = f_trimafterchar(lcline, "=")
+					trial[i].textbox = f_trimforchar(lcline, "=", "after")
 					triallangfound = true
 				elseif string.match(lcline, "trial.textbox.en") then
-					trial[i].textbox = f_trimafterchar(lcline, "=")
-				elseif string.match(f_trimbeforechar(lcline, "="), "^trial.textbox$") then
-					trial[i].textbox = f_trimafterchar(lcline, "=")
+					trial[i].textbox = f_trimforchar(lcline, "=", "after")
+				elseif string.match(f_trimforchar(lcline, "=", "before"), "^trial.textbox$") then
+					trial[i].textbox = f_trimforchar(lcline, "=", "after")
 					triallangfound = true
 				end
 			elseif lcline:find("trialstep." .. j .. ".text") and not trialsteplangfound then
 				if lcline:find("trialstep." .. j .. ".text." .. lang) then
-					trial[i].trialstep[j].text = f_trimafterchar(line, "=")
+					trial[i].trialstep[j].text = f_trimforchar(line, "=", "after")
 					trialsteplangfound = true
 				elseif string.match(lcline, "trialstep." .. j .. ".text.en") then
-					trial[i].trialstep[j].text = f_trimafterchar(line, "=")
-				elseif string.match(f_trimbeforechar(lcline, "="), "^trialstep." .. j .. ".text$") then
-					trial[i].trialstep[j].text = f_trimafterchar(line, "=")
+					trial[i].trialstep[j].text = f_trimforchar(line, "=", "after")
+				elseif string.match(f_trimforchar(lcline, "=", "before"), "^trialstep." .. j .. ".text$") then
+					trial[i].trialstep[j].text = f_trimforchar(line, "=", "after")
 					trialsteplangfound = true
 				end
-				trial[i].trialstep[j].text = f_trimafterchar(line, "=")
+				trial[i].trialstep[j].text = f_trimforchar(line, "=", "after")
 			elseif lcline:find("trialstep." .. j .. ".glyphs") then
-				trial[i].trialstep[j].glyphs = f_trimafterchar(line, "=")
+				trial[i].trialstep[j].glyphs = f_trimforchar(line, "=", "after")
 			elseif lcline:find("trialstep." .. j .. ".stateno") then
-				trial[i].trialstep[j].stateno = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
+				trial[i].trialstep[j].stateno = main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", ""))
 				for k = 1, #trial[i].trialstep[j].stateno, 1 do
 					local temp = trial[i].trialstep[j].stateno[k]
 					trial[i].trialstep[j].stateno[k] = f_str2number(main.f_strsplit('|', temp))
@@ -2049,44 +2039,44 @@ for row = 1, #main.t_selChars, 1 do
 					trial[i].trialstep[j].validfortickcount[k] = nil
 				end
 			elseif lcline:find("trialstep." .. j .. ".animno") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].animno = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].animno = main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", ""))
 					for k = 1, #trial[i].trialstep[j].animno, 1 do
 						local temp = trial[i].trialstep[j].animno[k]
 						trial[i].trialstep[j].animno[k] = f_str2number(main.f_strsplit('|', temp))
 					end
 				end
 			elseif lcline:find("trialstep." .. j .. ".hitcount") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].hitcount = f_str2number(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].hitcount = f_str2number(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 				end
 			elseif lcline:find("trialstep." .. j .. ".isthrow") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].isthrow = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].isthrow = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 				end
 			elseif lcline:find("trialstep." .. j .. ".iscounterhit") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].iscounterhit = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].iscounterhit = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 				end
 			elseif lcline:find("trialstep." .. j .. ".ishelper") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].ishelper = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].ishelper = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 				end
 			elseif lcline:find("trialstep." .. j .. ".isproj") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].isproj = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].isproj = f_str2boolean(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 				end
 			elseif lcline:find("trialstep." .. j .. ".validforvarvalpairs") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					local varvalpairs = f_str2number(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					local varvalpairs = f_str2number(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 					for ii = 1, #varvalpairs, 2 do
 						trial[i].trialstep[j].validforvar[ii] = varvalpairs[ii]
 						trial[i].trialstep[j].validforval[ii] = varvalpairs[ii+1]
 					end
 				end
 			elseif lcline:find("trialstep." .. j .. ".validfortickcount") then
-				if string.gsub(f_trimafterchar(lcline, "="),"%s+", "") ~= "" then
-					trial[i].trialstep[j].validfortickcount = f_str2number(main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", "")))
+				if string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "") ~= "" then
+					trial[i].trialstep[j].validfortickcount = f_str2number(main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", "")))
 				end
 			end
 		end

--- a/trials.lua
+++ b/trials.lua
@@ -1633,40 +1633,88 @@ function start.f_trialsSuccess(successstring, index)
 end
 
 function start.f_trialsFade()
-	local dummyposx = stagevar("playerinfo.p2startx")
-	local dummyposy = stagevar("playerinfo.p2starty")
-	local playerposx = stagevar("playerinfo.p1startx")
-	local playerposy = stagevar("playerinfo.p1starty")
+	local stagelocalcoordX = stagevar("stageinfo.localcoord.x")
+	local stagelocalcoordY = stagevar("stageinfo.localcoord.y")
+	local stageboundleft = stagevar("bound.screenleft")
+	local stageboundright = stagevar("bound.screenright")
+
+	local dummyposx = stagevar("playerinfo.p2startx") / (stagelocalcoordX/320)
+	local dummyposy = stagevar("playerinfo.p2starty") / (stagelocalcoordX/320)
+	local playerposx = stagevar("playerinfo.p1startx") / (stagelocalcoordX/320)
+	local playerposy = stagevar("playerinfo.p1starty") / (stagelocalcoordX/320)
+
+	local leftbound = stagevar("camera.boundleft")
+	local rightbound = stagevar("camera.boundright")
+
+	local cameraPosX = 0
+	local p1facing = 1
+	local p2facing = -1
+
+	player(2)
+	local p2posx = posX()
+	player(2)
+	local p2posy = posY()
+	local p1posx = posX()
+	local p1posy = posY()
+	local currentCameraPosX = cameraposX()
+	local currentCameraPosY = cameraposY()
+
     if start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
-		player(2)
-		if start.trials.trial[start.trials.currenttrial].dummypos == "left-corner" then
-			dummyposx = stagevar("playerinfo.leftbound")
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == "right-corner" then
-			dummyposx = stagevar("playerinfo.rightbound")
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == "close" then
-			dummyposx = posX() + const240p(10) * facing()
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == "medium" then
-			dummyposx = posX() + const240p(130) * facing()
-		elseif start.trials.trial[start.trials.currenttrial].dummypos == "far" then
-			dummyposx = posX() + const240p(260) * facing()
+		if start.trials.trial[start.trials.currenttrial].dummypos == 'left-corner' then
+			dummyposx = -(stagelocalcoordX/2 - stageboundleft) / (stagelocalcoordX/320)
+			p1facing = -1
+			p2facing = 1
+			cameraPosX = leftbound / (stagelocalcoordX/320)
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'right-corner' then
+			dummyposx = (stagelocalcoordX/2 - stageboundright) / (stagelocalcoordX/320)
+			cameraPosX = rightbound / (stagelocalcoordX/320)
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'close' then
+			dummyposx = p2posx + 10 * p1facing
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' then
+			dummyposx = p2posx + 130 * p1facing
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' then
+			dummyposx = p2posx + 260 * p1facing
 		end
-		player(1)
 	end
 	if start.trials.trial[start.trials.currenttrial].playerpos ~= nil then
-		if start.trials.trial[start.trials.currenttrial].playerpos == "left-corner" then
-			playerposx = stagevar("playerinfo.leftbound")
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == "right-corner" then
-			playerposx = stagevar("playerinfo.rightbound")
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == "close" then
-			playerposx = posX() + const240p(10) * facing()
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == "medium" then
-			playerposx = posX() + const240p(130) * facing()
-		elseif start.trials.trial[start.trials.currenttrial].playerpos == "far" then
-			playerposx = posX() + const240p(260) * facing()
+		if start.trials.trial[start.trials.currenttrial].playerpos == 'left-corner' then
+			playerposx = -(stagelocalcoordX/2 - stageboundleft) / (stagelocalcoordX/320)
+			p1facing = -1
+			p2facing = 1
+			cameraPosX = leftbound / (stagelocalcoordX/320)
+			if start.trials.trial[start.trials.currenttrial].dummypos == 'close' then
+				dummyposx = playerposx + 10 * p1facing
+			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' then
+				dummyposx = playerposx + 130 * p1facing
+			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' then
+				dummyposx = playerposx + 260 * p1facing
+			else
+				dummyposx = playerposx + 130 * p1facing
+			end
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'right-corner' then
+			playerposx = (stagelocalcoordX/2 - stageboundright) / (stagelocalcoordX/320)
+			cameraPosX = rightbound / (stagelocalcoordX/320)
+			if start.trials.trial[start.trials.currenttrial].dummypos == 'close' then
+				dummyposx = playerposx - 10 * p1facing
+			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'medium' then
+				dummyposx = playerposx - 130 * p1facing
+			elseif start.trials.trial[start.trials.currenttrial].dummypos == 'far' then
+				dummyposx = playerposx - 260 * p1facing
+			else
+				dummyposx = playerposx - 130 * p1facing
+			end
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'close' then
+			playerposx = dummyposx + 10 * p2facing
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'medium' then
+			playerposx = dummyposx + 130 * p2facing
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == 'far' then
+			playerposx = dummyposx + 260 * p2facing
 		end
 	elseif start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
-		playerposx = dummyposx + const240p(130) * -facing()
+		playerposx = dummyposx + 130 * p2facing
 	end
+
+	mapSet('_iksys_trialsCameraPosX', cameraPosX)
 	mapSet('_iksys_trialsDummyPosX', dummyposx)
 	mapSet('_iksys_trialsDummyPosY', dummyposy)
 	mapSet('_iksys_trialsPlayerPosX', playerposx)

--- a/trials.lua
+++ b/trials.lua
@@ -1633,6 +1633,51 @@ function start.f_trialsSuccess(successstring, index)
 end
 
 function start.f_trialsFade()
+	player(2)
+	local dummyposx = posX()
+	local dummyposy = posY()
+	player(1)
+	local playerposx = posX()
+	local playerposy = posY()
+
+    if start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
+		player(2)
+		if start.trials.trial[start.trials.currenttrial].dummypos == "left-corner" then
+			dummyposx = stagevar("playerinfo.leftbound")
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == "right-corner" then
+			dummyposx = stagevar("playerinfo.rightbound")
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == "close" then
+			dummyposx = posX() + const240p(10)*-facing()
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == "medium" then
+			dummyposx = posX() + const240p(130)*-facing()
+		elseif start.trials.trial[start.trials.currenttrial].dummypos == "far" then
+			dummyposx = posX() + const240p(260)*-facing()
+		end
+		player(1)
+		mapSet('_iksys_trialsDummyPosX', dummyposx)
+	else
+		mapSet('_iksys_trialsDummyPosX', stagevar("playerinfo.p2startx"))
+	end
+
+	if start.trials.trial[start.trials.currenttrial].playerpos ~= nil then
+		if start.trials.trial[start.trials.currenttrial].playerpos == "left-corner" then
+			playerposx = stagevar("playerinfo.leftbound")
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == "right-corner" then
+			playerposx = stagevar("playerinfo.rightbound")
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == "close" then
+			playerposx = posX() + const240p(10)*-facing()
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == "medium" then
+			playerposx = posX() + const240p(130)*-facing()
+		elseif start.trials.trial[start.trials.currenttrial].playerpos == "far" then
+			playerposx = posX() + const240p(260)*-facing()
+		end
+		mapSet('_iksys_trialsPlayerPosX', playerposx)
+	elseif start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
+		mapSet('_iksys_trialsPlayerPosX', dummyposx + const240p(130) * -facing())
+	else
+		mapSet('_iksys_trialsPlayerPosX', stagevar("playerinfo.p1startx"))
+	end
+	
 	-- This function is responsible for fadein/fadeout if trialsresetonsuccess is set to true.
 	if start.trials.draw.fadeout > 0 then
 		if not main.fadeActive then
@@ -1642,10 +1687,10 @@ function start.f_trialsFade()
 		start.trials.draw.fadeout = start.trials.draw.fadeout - 1
 	elseif start.trials.draw.fadein > 0 then
 		if main.fadeType == 'fadeout' then
-			mapSet('_iksys_trialsReposition', 1)
+			charMapSet(2, '_iksys_trialsReposition', 1)
 			main.f_fadeReset('fadein',motif.trials_mode)
 		elseif main.fadeType == 'fadein' then
-			mapSet('_iksys_trialsCameraReset', 1)
+			charMapSet(2, '_iksys_trialsCameraReset', 1)
 		end
 		main.f_fadeAnim(motif.trials_mode)
 		start.trials.draw.fadein = start.trials.draw.fadein - 1
@@ -1998,6 +2043,8 @@ for row = 1, #main.t_selChars, 1 do
 						complete = false,
 						p1life = -1,
 						p2life = -1,
+						playerpos = nil,
+						dummypos = nil,
 						showforvar = {nil},
 						showforval = {nil},
 						elapsedtime = 0,
@@ -2023,6 +2070,10 @@ for row = 1, #main.t_selChars, 1 do
 				trial[i].p1life = tonumber(f_trimforchar(lcline, "=", "after"))
 			elseif lcline:find("p2life") then
 				trial[i].p2life = tonumber(f_trimforchar(lcline, "=", "after"))
+			elseif lcline:find("playerpos") then
+				trial[i].playerpos = f_trimforchar(lcline, "=", "after")
+			elseif lcline:find("dummypos") then
+				trial[i].dummypos = f_trimforchar(lcline, "=", "after")
 			elseif lcline:find("showforvarvalpairs") then
 				showforvarvalpairsfound = false
 				temp = main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", ""))

--- a/trials.lua
+++ b/trials.lua
@@ -1002,6 +1002,7 @@ function start.f_trialsDummySetup()
 		mapSet('_iksys_trialsSetLife', lifemax())
 		setLife(lifemax())
 	end
+	player(2)
 	mapSet('_iksys_trialsDummyControl', 0)
 	if not start.trials.allclear and not start.trials.trial[start.trials.currenttrial].active then
 		if start.trials.trial[start.trials.currenttrial].dummymode == 'stand' then
@@ -1041,6 +1042,7 @@ function start.f_trialsDummySetup()
 		end
 		start.trials.trial[start.trials.currenttrial].active = true
 	end
+	player(1)
 end
 
 function start.f_trialsDrawer()

--- a/trials.lua
+++ b/trials.lua
@@ -1637,7 +1637,6 @@ function start.f_trialsFade()
 	local dummyposy = stagevar("playerinfo.p2starty")
 	local playerposx = stagevar("playerinfo.p1startx")
 	local playerposy = stagevar("playerinfo.p1starty")
-
     if start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
 		player(2)
 		if start.trials.trial[start.trials.currenttrial].dummypos == "left-corner" then
@@ -1645,35 +1644,32 @@ function start.f_trialsFade()
 		elseif start.trials.trial[start.trials.currenttrial].dummypos == "right-corner" then
 			dummyposx = stagevar("playerinfo.rightbound")
 		elseif start.trials.trial[start.trials.currenttrial].dummypos == "close" then
-			dummyposx = posX() + const240p(10)*-facing()
+			dummyposx = posX() + const240p(10) * facing()
 		elseif start.trials.trial[start.trials.currenttrial].dummypos == "medium" then
-			dummyposx = posX() + const240p(130)*-facing()
+			dummyposx = posX() + const240p(130) * facing()
 		elseif start.trials.trial[start.trials.currenttrial].dummypos == "far" then
-			dummyposx = posX() + const240p(260)*-facing()
+			dummyposx = posX() + const240p(260) * facing()
 		end
 		player(1)
 	end
-
 	if start.trials.trial[start.trials.currenttrial].playerpos ~= nil then
 		if start.trials.trial[start.trials.currenttrial].playerpos == "left-corner" then
 			playerposx = stagevar("playerinfo.leftbound")
 		elseif start.trials.trial[start.trials.currenttrial].playerpos == "right-corner" then
 			playerposx = stagevar("playerinfo.rightbound")
 		elseif start.trials.trial[start.trials.currenttrial].playerpos == "close" then
-			playerposx = posX() + const240p(10)*-facing()
+			playerposx = posX() + const240p(10) * facing()
 		elseif start.trials.trial[start.trials.currenttrial].playerpos == "medium" then
-			playerposx = posX() + const240p(130)*-facing()
+			playerposx = posX() + const240p(130) * facing()
 		elseif start.trials.trial[start.trials.currenttrial].playerpos == "far" then
-			playerposx = posX() + const240p(260)*-facing()
+			playerposx = posX() + const240p(260) * facing()
 		end
 	elseif start.trials.trial[start.trials.currenttrial].dummypos ~= nil then
-		playerpox = dummyposx + const240p(130) * -facing()
+		playerposx = dummyposx + const240p(130) * -facing()
 	end
-	print("dummyposX = " .. dummyposx .. ", playerposX = " .. playerposx)
 	mapSet('_iksys_trialsDummyPosX', dummyposx)
 	mapSet('_iksys_trialsDummyPosY', dummyposy)
-	-- mapSet('_iksys_trialsPlayerPosX', playerposx)
-	mapSet('_iksys_trialsPlayerPosX', dummyposx)
+	mapSet('_iksys_trialsPlayerPosX', playerposx)
 	mapSet('_iksys_trialsPlayerPosY', playerposy)
 	
 	-- This function is responsible for fadein/fadeout if trialsresetonsuccess is set to true.
@@ -1685,10 +1681,11 @@ function start.f_trialsFade()
 		start.trials.draw.fadeout = start.trials.draw.fadeout - 1
 	elseif start.trials.draw.fadein > 0 then
 		if main.fadeType == 'fadeout' then
-			charMapSet(2, '_iksys_trialsReposition', 1)
+			mapSet('_iksys_trialsReposition', 1)
+			print("flag set, ct = " .. start.trials.currenttrial)
 			main.f_fadeReset('fadein',motif.trials_mode)
 		elseif main.fadeType == 'fadein' then
-			charMapSet(2, '_iksys_trialsCameraReset', 1)
+			mapSet('_iksys_trialsCameraReset', 1)
 		end
 		main.f_fadeAnim(motif.trials_mode)
 		start.trials.draw.fadein = start.trials.draw.fadein - 1

--- a/trials.lua
+++ b/trials.lua
@@ -968,58 +968,62 @@ function start.f_trialsDummySetup()
 	--If the trials initializer was successful and the round animation is completed, we will start drawing trials on the screen
 	player(2)
 	setAILevel(0)
-	if start.trials.trial[start.trials.currenttrial].p2life ~= nil then
-		charMapSet(2, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p2life)
+	if start.trials.trial[start.trials.currenttrial].p2life > 0 then
+		mapSet(2, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p2life)
 		setLife(start.trials.trial[start.trials.currenttrial].p2life)
 	else
-		charMapSet(2, '_iksys_trialsSetLife', lifemax())
-		setLife(lifemax())
+		if map('_iksys_trialsSetLife') < lifemax() then
+			mapSet(2, '_iksys_trialsSetLife', lifemax())
+			--setLife(lifemax())
+		end
 	end
 	player(1)
 	--Set life for P1 and P2 if specified in the trial
-	if start.trials.trial[start.trials.currenttrial].p1life ~= nil then
-		charMapSet(1, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p1life)
+	if start.trials.trial[start.trials.currenttrial].p1life > 0 then
+		mapSet(1, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p1life)
 		setLife(start.trials.trial[start.trials.currenttrial].p1life)
 	else
-		charMapSet(1, '_iksys_trialsSetLife', lifemax())
-		setLife(lifemax())
+		if map('_iksys_trialsSetLife') < lifemax() then
+			mapSet(1, '_iksys_trialsSetLife', lifemax())
+			--setLife(lifemax())
+		end
 	end
-	charMapSet(2, '_iksys_trialsDummyControl', 0)
+	mapSet(2, '_iksys_trialsDummyControl', 0)
 	if not start.trials.allclear and not start.trials.trial[start.trials.currenttrial].active then
 		if start.trials.trial[start.trials.currenttrial].dummymode == 'stand' then
-			charMapSet(2, '_iksys_trialsDummyMode', 0)
+			mapSet(2, '_iksys_trialsDummyMode', 0)
 		elseif start.trials.trial[start.trials.currenttrial].dummymode == 'crouch' then
-			charMapSet(2, '_iksys_trialsDummyMode', 1)
+			mapSet(2, '_iksys_trialsDummyMode', 1)
 		elseif start.trials.trial[start.trials.currenttrial].dummymode == 'jump' then
-			charMapSet(2, '_iksys_trialsDummyMode', 2)
+			mapSet(2, '_iksys_trialsDummyMode', 2)
 		elseif start.trials.trial[start.trials.currenttrial].dummymode == 'wjump' then
-			charMapSet(2, '_iksys_trialsDummyMode', 3)
+			mapSet(2, '_iksys_trialsDummyMode', 3)
 		end
 		if start.trials.trial[start.trials.currenttrial].guardmode == 'none' then
-			charMapSet(2, '_iksys_trialsGuardMode', 0)
+			mapSet(2, '_iksys_trialsGuardMode', 0)
 		elseif start.trials.trial[start.trials.currenttrial].guardmode == 'auto' then
-			charMapSet(2, '_iksys_trialsGuardMode', 2)
+			mapSet(2, '_iksys_trialsGuardMode', 2)
 		end
 		if start.trials.trial[start.trials.currenttrial].buttonjam == 'none' then
-			charMapSet(2, '_iksys_trialsButtonJam', 0)
+			mapSet(2, '_iksys_trialsButtonJam', 0)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'a' then
-			charMapSet(2, '_iksys_trialsButtonJam', 1)
+			mapSet(2, '_iksys_trialsButtonJam', 1)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'b' then
-			charMapSet(2, '_iksys_trialsButtonJam', 2)
+			mapSet(2, '_iksys_trialsButtonJam', 2)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'c' then
-			charMapSet(2, '_iksys_trialsButtonJam', 3)
+			mapSet(2, '_iksys_trialsButtonJam', 3)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'x' then
-			charMapSet(2, '_iksys_trialsButtonJam', 4)
+			mapSet(2, '_iksys_trialsButtonJam', 4)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'y' then
-			charMapSet(2, '_iksys_trialsButtonJam', 5)
+			mapSet(2, '_iksys_trialsButtonJam', 5)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'z' then
-			charMapSet(2, '_iksys_trialsButtonJam', 6)
+			mapSet(2, '_iksys_trialsButtonJam', 6)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'start' then
-			charMapSet(2, '_iksys_trialsButtonJam', 7)
+			mapSet(2, '_iksys_trialsButtonJam', 7)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'd' then
-			charMapSet(2, '_iksys_trialsButtonJam', 8)
+			mapSet(2, '_iksys_trialsButtonJam', 8)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'w' then
-			charMapSet(2, '_iksys_trialsButtonJam', 9)
+			mapSet(2, '_iksys_trialsButtonJam', 9)
 		end
 		start.trials.trial[start.trials.currenttrial].active = true
 	end
@@ -1598,12 +1602,12 @@ end
 
 function start.f_trialsSuccess(successstring, index)
 	-- This function is responsible for drawing the Success or All Clear banners after a trial is completed successfully.
-	charMapSet(2, '_iksys_trialsDummyMode', 0)
-	charMapSet(2, '_iksys_trialsGuardMode', 0)
-	charMapSet(2, '_iksys_trialsButtonJam', 0)
-	charMapSet(1, '_iksys_trialsSetLife', lifemax())
+	mapSet(2, '_iksys_trialsDummyMode', 0)
+	mapSet(2, '_iksys_trialsGuardMode', 0)
+	mapSet(2, '_iksys_trialsButtonJam', 0)
+	mapSet(1, '_iksys_trialsSetLife', lifemax())
 	player(2)
-	charMapSet(2, '_iksys_trialsSetLife', lifemax())
+	mapSet(2, '_iksys_trialsSetLife', lifemax())
 	player(1)
 	if not start.trials.trial[index].complete or (successstring == "allclear" and not start.trials.allclear) then
 		-- Play sound only once
@@ -1636,10 +1640,10 @@ function start.f_trialsFade()
 		start.trials.draw.fadeout = start.trials.draw.fadeout - 1
 	elseif start.trials.draw.fadein > 0 then
 		if main.fadeType == 'fadeout' then
-			charMapSet(2, '_iksys_trialsReposition', 1)
+			mapSet(2, '_iksys_trialsReposition', 1)
 			main.f_fadeReset('fadein',motif.trials_mode)
 		elseif main.fadeType == 'fadein' then
-			charMapSet(2, '_iksys_trialsCameraReset', 1)
+			mapSet(2, '_iksys_trialsCameraReset', 1)
 		end
 		main.f_fadeAnim(motif.trials_mode)
 		start.trials.draw.fadein = start.trials.draw.fadein - 1
@@ -1729,10 +1733,10 @@ function start.f_trialsMode()
 		-- No trials present!
 		player(2)
 		setAILevel(0)
-		charMapSet(2, '_iksys_trialsSetLife', lifemax())
+		mapSet(2, '_iksys_trialsSetLife', lifemax())
 		player(1)
-		charMapSet(2, '_iksys_trialsDummyControl', 0)
-		charMapSet(1, '_iksys_trialsSetLife', lifemax())
+		mapSet(2, '_iksys_trialsDummyControl', 0)
+		mapSet(1, '_iksys_trialsSetLife', lifemax())
 		trialcounter = main.f_createTextImg(motif.trials_mode, 'trialcounter')
 		trialcounter:update({x = motif.trials_mode.trialcounter_pos[1], y = motif.trials_mode.trialcounter_pos[2], text = motif.trials_mode.trialcounter_notrialsdata_text})
 		trialcounter:draw()
@@ -1895,16 +1899,16 @@ function menu.f_trialsReset()
 	end
 	player(2)
 	setAILevel(0)
-	charMapSet(2, '_iksys_trialsDummyControl', 0)
-	charMapSet(2, '_iksys_trialsDummyMode', 0)
-	charMapSet(2, '_iksys_trialsGuardMode', 0)
-	charMapSet(2, '_iksys_trialsFallRecovery', 0)
-	charMapSet(2, '_iksys_trialsDistance', 0)
-	charMapSet(2, '_iksys_trialsButtonJam', 0)
-	charMapSet(2, '_iksys_trialsReposition', 0)
-	charMapSet(2, '_iksys_trialsSetLife', lifemax())
+	mapSet(2, '_iksys_trialsDummyControl', 0)
+	mapSet(2, '_iksys_trialsDummyMode', 0)
+	mapSet(2, '_iksys_trialsGuardMode', 0)
+	mapSet(2, '_iksys_trialsFallRecovery', 0)
+	mapSet(2, '_iksys_trialsDistance', 0)
+	mapSet(2, '_iksys_trialsButtonJam', 0)
+	mapSet(2, '_iksys_trialsReposition', 0)
+	mapSet(2, '_iksys_trialsSetLife', lifemax())
 	player(1)
-	charMapSet(1, '_iksys_trialsSetLife', lifemax())
+	mapSet(1, '_iksys_trialsSetLife', lifemax())
 end
 
 --;===========================================================
@@ -1990,8 +1994,8 @@ for row = 1, #main.t_selChars, 1 do
 						buttonjam = "none",
 						active = false,
 						complete = false,
-						p1life = nil,
-						p2life = nil,
+						p1life = -1,
+						p2life = -1,
 						showforvar = {nil},
 						showforval = {nil},
 						elapsedtime = 0,

--- a/trials.lua
+++ b/trials.lua
@@ -968,62 +968,67 @@ function start.f_trialsDummySetup()
 	--If the trials initializer was successful and the round animation is completed, we will start drawing trials on the screen
 	player(2)
 	setAILevel(0)
-	if start.trials.trial[start.trials.currenttrial].p2life > 0 then
-		mapSet(2, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p2life)
-		setLife(start.trials.trial[start.trials.currenttrial].p2life)
-	else
-		if map('_iksys_trialsSetLife') < lifemax() then
-			mapSet(2, '_iksys_trialsSetLife', lifemax())
-			--setLife(lifemax())
+	if start.trials.currenttrial <= #start.trials.trial then
+		if start.trials.trial[start.trials.currenttrial].p2life > 0 then
+			mapSet('_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p2life)
+			setLife(start.trials.trial[start.trials.currenttrial].p2life)
+		elseif map('_iksys_trialsSetLife') < lifemax() then
+			mapSet('_iksys_trialsSetLife', lifemax())
+			setLife(lifemax())
 		end
+	else
+		mapSet('_iksys_trialsSetLife', lifemax())
+		setLife(lifemax())
 	end
 	player(1)
-	--Set life for P1 and P2 if specified in the trial
-	if start.trials.trial[start.trials.currenttrial].p1life > 0 then
-		mapSet(1, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p1life)
-		setLife(start.trials.trial[start.trials.currenttrial].p1life)
-	else
-		if map('_iksys_trialsSetLife') < lifemax() then
-			mapSet(1, '_iksys_trialsSetLife', lifemax())
-			--setLife(lifemax())
+	if start.trials.currenttrial <= #start.trials.trial then
+		if start.trials.trial[start.trials.currenttrial].p1life > 0 then
+			mapSet('_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p1life)
+			setLife(start.trials.trial[start.trials.currenttrial].p1life)
+		elseif map('_iksys_trialsSetLife') < lifemax() then
+			mapSet('_iksys_trialsSetLife', lifemax())
+			setLife(lifemax())
 		end
+	else
+		mapSet('_iksys_trialsSetLife', lifemax())
+		setLife(lifemax())
 	end
-	mapSet(2, '_iksys_trialsDummyControl', 0)
+	mapSet('_iksys_trialsDummyControl', 0)
 	if not start.trials.allclear and not start.trials.trial[start.trials.currenttrial].active then
 		if start.trials.trial[start.trials.currenttrial].dummymode == 'stand' then
-			mapSet(2, '_iksys_trialsDummyMode', 0)
+			mapSet('_iksys_trialsDummyMode', 0)
 		elseif start.trials.trial[start.trials.currenttrial].dummymode == 'crouch' then
-			mapSet(2, '_iksys_trialsDummyMode', 1)
+			mapSet('_iksys_trialsDummyMode', 1)
 		elseif start.trials.trial[start.trials.currenttrial].dummymode == 'jump' then
-			mapSet(2, '_iksys_trialsDummyMode', 2)
+			mapSet('_iksys_trialsDummyMode', 2)
 		elseif start.trials.trial[start.trials.currenttrial].dummymode == 'wjump' then
-			mapSet(2, '_iksys_trialsDummyMode', 3)
+			mapSet('_iksys_trialsDummyMode', 3)
 		end
 		if start.trials.trial[start.trials.currenttrial].guardmode == 'none' then
-			mapSet(2, '_iksys_trialsGuardMode', 0)
+			mapSet('_iksys_trialsGuardMode', 0)
 		elseif start.trials.trial[start.trials.currenttrial].guardmode == 'auto' then
-			mapSet(2, '_iksys_trialsGuardMode', 2)
+			mapSet('_iksys_trialsGuardMode', 2)
 		end
 		if start.trials.trial[start.trials.currenttrial].buttonjam == 'none' then
-			mapSet(2, '_iksys_trialsButtonJam', 0)
+			mapSet('_iksys_trialsButtonJam', 0)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'a' then
-			mapSet(2, '_iksys_trialsButtonJam', 1)
+			mapSet('_iksys_trialsButtonJam', 1)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'b' then
-			mapSet(2, '_iksys_trialsButtonJam', 2)
+			mapSet('_iksys_trialsButtonJam', 2)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'c' then
-			mapSet(2, '_iksys_trialsButtonJam', 3)
+			mapSet('_iksys_trialsButtonJam', 3)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'x' then
-			mapSet(2, '_iksys_trialsButtonJam', 4)
+			mapSet('_iksys_trialsButtonJam', 4)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'y' then
-			mapSet(2, '_iksys_trialsButtonJam', 5)
+			mapSet('_iksys_trialsButtonJam', 5)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'z' then
-			mapSet(2, '_iksys_trialsButtonJam', 6)
+			mapSet('_iksys_trialsButtonJam', 6)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'start' then
-			mapSet(2, '_iksys_trialsButtonJam', 7)
+			mapSet('_iksys_trialsButtonJam', 7)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'd' then
-			mapSet(2, '_iksys_trialsButtonJam', 8)
+			mapSet('_iksys_trialsButtonJam', 8)
 		elseif start.trials.trial[start.trials.currenttrial].buttonjam == 'w' then
-			mapSet(2, '_iksys_trialsButtonJam', 9)
+			mapSet('_iksys_trialsButtonJam', 9)
 		end
 		start.trials.trial[start.trials.currenttrial].active = true
 	end
@@ -1602,12 +1607,9 @@ end
 
 function start.f_trialsSuccess(successstring, index)
 	-- This function is responsible for drawing the Success or All Clear banners after a trial is completed successfully.
-	mapSet(2, '_iksys_trialsDummyMode', 0)
-	mapSet(2, '_iksys_trialsGuardMode', 0)
-	mapSet(2, '_iksys_trialsButtonJam', 0)
-	mapSet(1, '_iksys_trialsSetLife', lifemax())
-	player(2)
-	mapSet(2, '_iksys_trialsSetLife', lifemax())
+	mapSet('_iksys_trialsDummyMode', 0)
+	mapSet('_iksys_trialsGuardMode', 0)
+	mapSet('_iksys_trialsButtonJam', 0)
 	player(1)
 	if not start.trials.trial[index].complete or (successstring == "allclear" and not start.trials.allclear) then
 		-- Play sound only once
@@ -1640,10 +1642,10 @@ function start.f_trialsFade()
 		start.trials.draw.fadeout = start.trials.draw.fadeout - 1
 	elseif start.trials.draw.fadein > 0 then
 		if main.fadeType == 'fadeout' then
-			mapSet(2, '_iksys_trialsReposition', 1)
+			mapSet('_iksys_trialsReposition', 1)
 			main.f_fadeReset('fadein',motif.trials_mode)
 		elseif main.fadeType == 'fadein' then
-			mapSet(2, '_iksys_trialsCameraReset', 1)
+			mapSet('_iksys_trialsCameraReset', 1)
 		end
 		main.f_fadeAnim(motif.trials_mode)
 		start.trials.draw.fadein = start.trials.draw.fadein - 1
@@ -1733,10 +1735,10 @@ function start.f_trialsMode()
 		-- No trials present!
 		player(2)
 		setAILevel(0)
-		mapSet(2, '_iksys_trialsSetLife', lifemax())
+		mapSet('_iksys_trialsSetLife', lifemax())
 		player(1)
-		mapSet(2, '_iksys_trialsDummyControl', 0)
-		mapSet(1, '_iksys_trialsSetLife', lifemax())
+		mapSet('_iksys_trialsDummyControl', 0)
+		mapSet('_iksys_trialsSetLife', lifemax())
 		trialcounter = main.f_createTextImg(motif.trials_mode, 'trialcounter')
 		trialcounter:update({x = motif.trials_mode.trialcounter_pos[1], y = motif.trials_mode.trialcounter_pos[2], text = motif.trials_mode.trialcounter_notrialsdata_text})
 		trialcounter:draw()
@@ -1899,16 +1901,16 @@ function menu.f_trialsReset()
 	end
 	player(2)
 	setAILevel(0)
-	mapSet(2, '_iksys_trialsDummyControl', 0)
-	mapSet(2, '_iksys_trialsDummyMode', 0)
-	mapSet(2, '_iksys_trialsGuardMode', 0)
-	mapSet(2, '_iksys_trialsFallRecovery', 0)
-	mapSet(2, '_iksys_trialsDistance', 0)
-	mapSet(2, '_iksys_trialsButtonJam', 0)
-	mapSet(2, '_iksys_trialsReposition', 0)
-	mapSet(2, '_iksys_trialsSetLife', lifemax())
+	mapSet('_iksys_trialsDummyControl', 0)
+	mapSet('_iksys_trialsDummyMode', 0)
+	mapSet('_iksys_trialsGuardMode', 0)
+	mapSet('_iksys_trialsFallRecovery', 0)
+	mapSet('_iksys_trialsDistance', 0)
+	mapSet('_iksys_trialsButtonJam', 0)
+	mapSet('_iksys_trialsReposition', 0)
+	mapSet('_iksys_trialsSetLife', lifemax())
 	player(1)
-	mapSet(1, '_iksys_trialsSetLife', lifemax())
+	mapSet('_iksys_trialsSetLife', lifemax())
 end
 
 --;===========================================================

--- a/trials.lua
+++ b/trials.lua
@@ -968,7 +968,22 @@ function start.f_trialsDummySetup()
 	--If the trials initializer was successful and the round animation is completed, we will start drawing trials on the screen
 	player(2)
 	setAILevel(0)
+	if start.trials.trial[start.trials.currenttrial].p2life ~= nil then
+		charMapSet(2, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p2life)
+		setLife(start.trials.trial[start.trials.currenttrial].p2life)
+	else
+		charMapSet(2, '_iksys_trialsSetLife', lifemax())
+		setLife(lifemax())
+	end
 	player(1)
+	--Set life for P1 and P2 if specified in the trial
+	if start.trials.trial[start.trials.currenttrial].p1life ~= nil then
+		charMapSet(1, '_iksys_trialsSetLife', start.trials.trial[start.trials.currenttrial].p1life)
+		setLife(start.trials.trial[start.trials.currenttrial].p1life)
+	else
+		charMapSet(1, '_iksys_trialsSetLife', lifemax())
+		setLife(lifemax())
+	end
 	charMapSet(2, '_iksys_trialsDummyControl', 0)
 	if not start.trials.allclear and not start.trials.trial[start.trials.currenttrial].active then
 		if start.trials.trial[start.trials.currenttrial].dummymode == 'stand' then
@@ -1586,6 +1601,10 @@ function start.f_trialsSuccess(successstring, index)
 	charMapSet(2, '_iksys_trialsDummyMode', 0)
 	charMapSet(2, '_iksys_trialsGuardMode', 0)
 	charMapSet(2, '_iksys_trialsButtonJam', 0)
+	charMapSet(1, '_iksys_trialsSetLife', lifemax())
+	player(2)
+	charMapSet(2, '_iksys_trialsSetLife', lifemax())
+	player(1)
 	if not start.trials.trial[index].complete or (successstring == "allclear" and not start.trials.allclear) then
 		-- Play sound only once
 		sndPlay(motif.files.snd_data, motif.trials_mode[successstring .. '_snd'][1], motif.trials_mode[successstring .. '_snd'][2])
@@ -1710,8 +1729,10 @@ function start.f_trialsMode()
 		-- No trials present!
 		player(2)
 		setAILevel(0)
+		charMapSet(2, '_iksys_trialsSetLife', lifemax())
 		player(1)
 		charMapSet(2, '_iksys_trialsDummyControl', 0)
+		charMapSet(1, '_iksys_trialsSetLife', lifemax())
 		trialcounter = main.f_createTextImg(motif.trials_mode, 'trialcounter')
 		trialcounter:update({x = motif.trials_mode.trialcounter_pos[1], y = motif.trials_mode.trialcounter_pos[2], text = motif.trials_mode.trialcounter_notrialsdata_text})
 		trialcounter:draw()
@@ -1881,7 +1902,9 @@ function menu.f_trialsReset()
 	charMapSet(2, '_iksys_trialsDistance', 0)
 	charMapSet(2, '_iksys_trialsButtonJam', 0)
 	charMapSet(2, '_iksys_trialsReposition', 0)
+	charMapSet(2, '_iksys_trialsSetLife', lifemax())
 	player(1)
+	charMapSet(1, '_iksys_trialsSetLife', lifemax())
 end
 
 --;===========================================================
@@ -1967,6 +1990,8 @@ for row = 1, #main.t_selChars, 1 do
 						buttonjam = "none",
 						active = false,
 						complete = false,
+						p1life = nil,
+						p2life = nil,
 						showforvar = {nil},
 						showforval = {nil},
 						elapsedtime = 0,
@@ -1988,6 +2013,10 @@ for row = 1, #main.t_selChars, 1 do
 				trial[i].guardmode = f_trimforchar(lcline, "=", "after")
 			elseif lcline:find("dummybuttonjam") then
 				trial[i].buttonjam = f_trimforchar(lcline, "=", "after")
+			elseif lcline:find("p1life") then
+				trial[i].p1life = tonumber(f_trimforchar(lcline, "=", "after"))
+			elseif lcline:find("p2life") then
+				trial[i].p2life = tonumber(f_trimforchar(lcline, "=", "after"))
 			elseif lcline:find("showforvarvalpairs") then
 				showforvarvalpairsfound = false
 				temp = main.f_strsplit(',', string.gsub(f_trimforchar(lcline, "=", "after"),"%s+", ""))

--- a/trials.lua
+++ b/trials.lua
@@ -1416,6 +1416,7 @@ function start.f_trialsChecker()
 		local maincharcheck = false
 		local statecheck = false
 		local animcheck = true
+
 		player(2)
 		local attackerid = gethitvar('id')
 		player(1)
@@ -1435,7 +1436,7 @@ function start.f_trialsChecker()
 		-- Check states and anims; iterate over 'or' operand if multiple states and/or anims are provided
 		local desiredstates = start.trials.trial[ct].trialstep[cts].stateno[ctms]
 		for k = 1, #desiredstates, 1 do
-			if attackerstate == desiredstates[k] then
+			if stateno() == desiredstates[k] or attackerstate == desiredstates[k] then
 				statecheck = true
 				break
 			end
@@ -1444,7 +1445,7 @@ function start.f_trialsChecker()
 			animcheck = false
 			local desiredanims = start.trials.trial[ct].trialstep[cts].animno[ctms]
 			for k = 1, #desiredanims, 1 do
-				if attackeranim == desiredanims[k] then
+				if anim() == desiredanims[k] or attackeranim == desiredanims[k] then
 					animcheck = true
 					break
 				end

--- a/trials.lua
+++ b/trials.lua
@@ -1979,6 +1979,7 @@ for row = 1, #main.t_selChars, 1 do
 						showforvar = {nil},
 						showforval = {nil},
 						elapsedtime = 0,
+						textbox = "",
 						textcnt = 0,
 						starttick = roundtime()+1,
 						trialstep = {},

--- a/trials.lua
+++ b/trials.lua
@@ -53,6 +53,20 @@ local function f_trimafterchar(line, char)
 	return line
 end
 
+local function f_trimbeforechar(line, char)
+	-- trims a string before a specified character.
+	-- also trims leading and trailing whitespace
+	x = string.find(line, char)
+	if x ~= nil then
+		line = string.sub(line, 1, x-1)
+		line = string.gsub(line, '^%s*(.-)%s*$', '%1')
+		line = string.gsub(line, '[ \t]+%f[\r\n%z]', '')
+	else
+		line = ""
+	end
+	return line
+end
+
 local function f_str2boolean(str)
 	-- converts a table of "true" and "false" strings to bool
     local bool = {}
@@ -1909,6 +1923,7 @@ for row = 1, #main.t_selChars, 1 do
 
 			if lcline:find("trialstep." .. j+1 .. ".") then
 				j = j + 1
+				trialsteplangfound = false
 				trial[i].trialstep[j] = {
 					numofmicrosteps = 1,
 					text = "",
@@ -1952,6 +1967,8 @@ for row = 1, #main.t_selChars, 1 do
 				if lcline:match('^trialdef') then --matched trialdef block
 					i = i + 1 -- increment Trial number
 					j = 0 -- reset trialstep number
+					triallangfound = false
+					lang = gameOption('Config.Language'):lower()
 					trial[i] = {
 						name = "",
 						dummymode = "stand",
@@ -1964,7 +1981,6 @@ for row = 1, #main.t_selChars, 1 do
 						elapsedtime = 0,
 						textcnt = 0,
 						starttick = roundtime()+1,
-						lang = gameOption('Config.Language'):lower(),
 						trialstep = {},
 					}
 					temp = {}
@@ -1981,19 +1997,7 @@ for row = 1, #main.t_selChars, 1 do
 			elseif lcline:find("dummybuttonjam") then
 				trial[i].buttonjam = f_trimafterchar(lcline, "=")
 			elseif lcline:find("showforvarvalpairs") then
--- 				local text = "hello.world.en"
-
--- -- This will match "hello" because it's a partial match at the beginning
--- local partial_match = string.match(text, "hello")
--- print(partial_match) -- Output: hello
-
--- -- This will *not* match because "hello" is not the full string
--- local full_string_no_match = string.match(text, "^hello$")
--- print(full_string_no_match) -- Output: nil
-
--- -- This will match because the entire string "hello world" matches the pattern
--- local full_string_match = string.match(text, "^hello.world.en$")
--- print(full_string_match) -- Output: hello world
+				showforvarvalpairsfound = false
 				temp = main.f_strsplit(',', string.gsub(f_trimafterchar(lcline, "="),"%s+", ""))
 				trial[i].showforvar = {}
 				trial[i].showforval = {}
@@ -2001,17 +2005,26 @@ for row = 1, #main.t_selChars, 1 do
 					trial[i].showforvar[#trial[i].showforvar+1] = tonumber(temp[k])
 					trial[i].showforval[#trial[i].showforval+1] = f_str2number(main.f_strsplit('|', temp[k+1]))
 				end
-			elseif lcline:find("textbox." .. trial[i].lang) and not trial[i].langfound then
-				trial[i].textbox = f_trimafterchar(lcline, "=")
-				trial[i].langfound = true
-				if lcline:find("textbox." .. trial[i].lang) then
+			elseif lcline:find("textbox") and not triallangfound then
+				if lcline:find("textbox." .. lang) then
 					trial[i].textbox = f_trimafterchar(lcline, "=")
-				elseif lcline:find("textbox.en") then
+					triallangfound = true
+				elseif string.match(lcline, "trial.textbox.en") then
 					trial[i].textbox = f_trimafterchar(lcline, "=")
-				elseif lcline:find("textbox") then
+				elseif string.match(f_trimbeforechar(lcline, "="), "^trial.textbox$") then
 					trial[i].textbox = f_trimafterchar(lcline, "=")
+					triallangfound = true
 				end
-			elseif lcline:find("trialstep." .. j .. ".text") then
+			elseif lcline:find("trialstep." .. j .. ".text") and not trialsteplangfound then
+				if lcline:find("trialstep." .. j .. ".text." .. lang) then
+					trial[i].trialstep[j].text = f_trimafterchar(line, "=")
+					trialsteplangfound = true
+				elseif string.match(lcline, "trialstep." .. j .. ".text.en") then
+					trial[i].trialstep[j].text = f_trimafterchar(line, "=")
+				elseif string.match(f_trimbeforechar(lcline, "="), "^trialstep." .. j .. ".text$") then
+					trial[i].trialstep[j].text = f_trimafterchar(line, "=")
+					trialsteplangfound = true
+				end
 				trial[i].trialstep[j].text = f_trimafterchar(line, "=")
 			elseif lcline:find("trialstep." .. j .. ".glyphs") then
 				trial[i].trialstep[j].glyphs = f_trimafterchar(line, "=")

--- a/trials.zss
+++ b/trials.zss
@@ -12,27 +12,26 @@
 #===============================================================================
 # Functions
 #===============================================================================
-# [Function TrialsInitialPosition()]
-# # Get initial positions
-# for pn = 1; 2; 1 {
-# 	mapSet{map:"_iksys_trialsInitPosX"; value: player($pn),Pos x; redirectID: player($pn),id;}
-# 	mapSet{map:"_iksys_trialsInitPosY"; value: player($pn),Pos y; redirectID: player($pn),id;}
-# 	mapSet{map:"_iksys_trialsCameraPosX"; value: player($pn),CameraPos x; redirectID: player($pn),id;}
-# 	mapSet{map:"_iksys_trialsCameraPosY"; value: player($pn),CameraPos y; redirectID: player($pn),id;}
-# 	mapSet{map:"_iksys_trialsScreenPosX"; value: player($pn),ScreenPos x; redirectID: player($pn),id;}
-# 	mapSet{map:"_iksys_trialsScreenPosY"; value: player($pn),ScreenPos y; redirectID: player($pn),id;}
-# }
-
 [Function TrialsReposition()]
-Camera{view: free; pos:0,0;}
-# for pn = 1; 2; 1 {
-# 	if player($pn), map(_iksys_trialsInitPosX) != 0 {
-# 		PosSet{x:player($pn), map(_iksys_trialsInitPosX); y:player($pn), map(_iksys_trialsInitPosY); redirectID: player($pn),id;}
-# 	}
-# }
 if map(_iksys_trialsReposition) != 0 {
-	PosSet{x: player(1), map(_iksys_trialsPlayerPosX); y: player(1), map(_iksys_trialsPlayerPosY); redirectID: player(1),id;}
-	PosSet{x: player(2), map(_iksys_trialsDummyPosX); y: player(2), map(_iksys_trialsDummyPosY); redirectID: player(2),id;}
+	PrintToConsole{
+		text: "player1posx: %f, dummyposx: %f";
+		params: map(_iksys_trialsPlayerPosX), map(_iksys_trialsDummyPosX);
+	}
+	Camera{
+		view: free; 
+		pos: (map(_iksys_trialsPlayerPosX) + map(_iksys_trialsDummyPosX))/2, (map(_iksys_trialsPlayerPosY) + map(_iksys_trialsDummyPosY))/2;
+	}
+	PosSet{
+		x: map(_iksys_trialsPlayerPosX); 
+		y: map(_iksys_trialsPlayerPosY); 
+		redirectID: player(1),id;
+	}
+	PosSet{
+		x: map(_iksys_trialsDummyPosX);
+		y: map(_iksys_trialsDummyPosY);
+		redirectID: player(2),id;
+	}
 }
 
 [Function TrialsResetCamera()]
@@ -50,7 +49,6 @@ ignoreHitPause if gameMode = "trials" {
 		map(_iksys_trialsLifeTimer) := 0;
 		map(_iksys_trialsPowerTimer) := 0;
 		map(_iksys_trialsReposition) := 0;
-		# call TrialsInitialPosition();
 	}
 	# Life and Power recovery
 	if !isHelper {

--- a/trials.zss
+++ b/trials.zss
@@ -1,4 +1,4 @@
-# Mugen style Training Mode global code
+# Trials Mode global code
 # maps set via Pause Menu (menu.lua)
 # _iksys_trialsDummyControl: 0 - cooperative, 1 - ai, 2 - manual
 # _iksys_trialsGuardMode: 0 - none, 1 - auto, 2 - all, 3 - random
@@ -11,27 +11,6 @@
 #===============================================================================
 # Functions
 #===============================================================================
-[Function TrialsRecovery(pn)]
-# Life recovery
-if player($pn),moveType = H || player($pn),dizzy {
-	mapSet{map: "_iksys_trialsLifeTimer"; value: 0; redirectid: player($pn),id}
-} else if player($pn),map(_iksys_trialsLifeTimer) >= 60 {
-	lifeSet{value: player($pn),map(_iksys_trialsSetLife); redirectid: player($pn),id}
-	redLifeSet{value: player($pn),map(_iksys_trialsSetLife); redirectid: player($pn),id}
-	mapSet{map: "_iksys_trialsLifeTimer"; value: 0; redirectid: player($pn),id}
-} else {
-	mapAdd{map: "_iksys_trialsLifeTimer"; value: 1; redirectid: player($pn),id}
-}
-# Power recovery
-if player($pn),ctrl = 0 {
-	mapSet{map: "_iksys_trialsPowerTimer"; value: 0; redirectid: player($pn),id}
-} else if player($pn),map(_iksys_trialsPowerTimer) >= 60 {
-	powerSet{value: player($pn),powerMax; redirectid: player($pn),id}
-	mapSet{map: "_iksys_trialsPowerTimer"; value: 0; redirectid: player($pn),id}
-} else {
-	mapAdd{map: "_iksys_trialsPowerTimer"; value: 1; redirectid: player($pn),id}
-}
-
 [Function TrialsInitialPosition()]
 # Get initial positions
 for pn = 1; 2; 1 {
@@ -57,233 +36,278 @@ Camera{view: fighting}
 #===============================================================================
 [StateDef -4]
 
-ignoreHitPause if gameMode != "trials" || isHelper || teamSide != 2 {
-	# Do nothing, not trials more or statedef executed by helper or not P2
-} else ignoreHitPause if roundState = 0 {
+ignoreHitPause if gameMode = "trials" {
 	# Round start reset
-	powerSet{value: player(1),powerMax; redirectid: player(1),id}
-	powerSet{value: player(2),powerMax; redirectid: player(2),id}
-	map(_iksys_trialsLifeTimer) := 0;
-	map(_iksys_trialsPowerTimer) := 0;
-	map(_iksys_trialsDirection) := 0;
-	map(_iksys_trialsAirJumpNum) := 0;
-	map(_iksys_trialsReposition) := 0;
-	call TrialsInitialPosition();
-} else ignoreHitPause if roundState = 2 {
-	assertSpecial{flag: globalNoKo}
+	if roundState = 0 {
+		powerSet{value: powerMax}
+		map(_iksys_trialsLifeTimer) := 0;
+		map(_iksys_trialsPowerTimer) := 0;
+		map(_iksys_trialsReposition) := 0;
+		call TrialsInitialPosition();
+	}
 	# Life and Power recovery
-	for i = 1; player(1),numPartner + 1; 1 {
-		call TrialsRecovery($i * 2 - 1);
-	}
-	for i = 1; player(2),numPartner + 1; 1 {
-		call TrialsRecovery($i * 2);
-	}
-	# Dummy Control: Cooperative
-	if aiLevel = 0 && map(_iksys_trialsDummyControl) = 0 {
-		# Guard mode: Random
-		if map(_iksys_trialsGuardMode) = 3 {
-			if random < 500 {
-				assertSpecial{flag: autoGuard}
-			}
-		# Guard mode: All
-		} else if map(_iksys_trialsGuardMode) = 2 {
-			assertSpecial{flag: autoGuard}
-		# Guard mode: Auto
-		} else if map(_iksys_trialsGuardMode) = 1 {
-			if moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
-				map(_iksys_trialsAutoGuardTimer) := 15;
-			} else {
-				map(_iksys_trialsAutoGuardTimer) := (map(_iksys_trialsAutoGuardTimer) - 1);
-			}
-			if map(_iksys_trialsAutoGuardTimer) > 0 {
-				assertSpecial{flag: autoGuard}
-			}
-		}
-		# Distance
-		let dir = 0;
-		if map(_iksys_trialsDistance) != 0 {
-			# Close
-			if map(_iksys_trialsDistance) = 1 && p2BodyDist x > const240p(10) {
-				let dir = 1;
-				map(_iksys_trialsDirection) := 1;
-			# Medium
-			} else if map(_iksys_trialsDistance) = 2 {
-				if p2BodyDist x > const240p(130) {
-					let dir = 1;
-					map(_iksys_trialsDirection) := 1;
-				} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
-					let dir = -1;
-					map(_iksys_trialsDirection) := -1;
-				}
-			# Far
-			} else if map(_iksys_trialsDistance) = 3 {
-				if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
-					let dir = -1;
-					map(_iksys_trialsDirection) := -1;
-				}
-			# Reset to Center
-			} else if map(_iksys_trialsDistance) = 4 {
-
-			}
-		}
-		if map(_iksys_trialsDirection) != 0 {
-			# if adjusting position is no longer needed
-			if $dir = 0 {
-				# maintain assertion only if dummy and nearest P1 are moving in the same direction
-				if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
-					map(_iksys_trialsDirection) := 0;
-				}
-			}
-			# if dummy should move forward and player is not trying to move dummy back
-			if map(_iksys_trialsDirection) = 1 && command != "holdback" {
-				if facing = 1 {
-					assertInput{flag: R}
-					if numHelper {
-						for i = 1; numHelper; 1 {
-							assertInput{flag: R; redirectID: helperIndex($i), ID}
-						}
-					}
-				} else {
-					assertInput{flag: L}
-					if numHelper {
-						for i = 1; numHelper; 1 {
-							assertInput{flag: L; redirectID: helperIndex($i), ID}
-						}
-					}
-				}
-			# if dummy should move backward and player is not trying to move dummy forward
-			} else if map(_iksys_trialsDirection) = -1 && command != "holdfwd" {
-				if facing = 1 {
-					assertInput{flag: L}
-					if numHelper {
-						for i = 1; numHelper; 1 {
-							assertInput{flag: L; redirectID: helperIndex($i), ID}
-						}
-					}
-				} else {
-					assertInput{flag: R}
-					if numHelper {
-						for i = 1; numHelper; 1 {
-							assertInput{flag: R; redirectID: helperIndex($i), ID}
-						}
-					}
-				}
-			}
+	if !isHelper {
+		# Life
+		if moveType = H || dizzy {
+			mapSet{map: "_iksys_trialsLifeTimer"; value: 0}
 		} else {
-			# Dummy mode
-			switch map(_iksys_trialsDummyMode) {
-			# Crouch
-			case 1:
-				assertInput{flag: D}
-				if numHelper {
-					for i = 1; numHelper; 1 {
-						assertInput{flag: D; redirectID: helperIndex($i), ID}
-					}
-				}
-			# Jump
-			case 2:
-				assertInput{flag: U}
-				if numHelper {
-					for i = 1; numHelper; 1 {
-						assertInput{flag: U; redirectID: helperIndex($i), ID}
-					}
-				}
-			# W Jump
-			case 3:
-				if vel y >= 0 {
-					assertInput{flag: U}
-					if numHelper {
-						for i = 1; numHelper; 1 {
-							assertInput{flag: U; redirectID: helperIndex($i), ID}
-						}
-					}
-				}
-			default:
-				# Do nothing
+			mapAdd{map: "_iksys_trialsLifeTimer"; value: 1}
+		}
+		if map(_iksys_trialsLifeTimer) >= 60 {
+			if map(_iksys_trialsSetLife) > 0 {
+				lifeSet{value: map(_iksys_trialsSetLife)}
+				redLifeSet{value: map(_iksys_trialsSetLife)}
+			} else {
+				lifeSet{value: lifeMax}
+				redLifeSet{value: lifeMax}
 			}
-			# Button jam
-			if map(_iksys_trialsButtonJam) > 0 {
-				if map(_iksys_trialsButtonJamDelay) > 0 {
-					mapAdd{map: "_iksys_trialsButtonJamDelay"; value: -1}
+			mapSet{map: "_iksys_trialsLifeTimer"; value: 0}
+		}
+		# Power
+		if ctrl = 0 {
+			mapSet{map: "_iksys_trialsPowerTimer"; value: 0}
+		} else {
+			mapAdd{map: "_iksys_trialsPowerTimer"; value: 1}
+		}
+		if map(_iksys_trialsPowerTimer) >= 60 {
+			powerSet{value: powerMax}
+			mapSet{map: "_iksys_trialsPowerTimer"; value: 0}
+		}
+	}
+	# Disable normal KO behavior
+	assertSpecial{
+		flag: globalNoKo;
+		flag2: noKoFall;
+		flag3: noKoVelocity;
+	}
+	# Force players out of KO state
+	if stateNo = 5150 && time >= 90 && alive {
+		selfState{value: 5120}
+	}
+	# Skip round and fight calls
+	if roundState < 2 {
+		assertSpecial{flag: skipRoundDisplay; flag2: skipFightDisplay}
+	}
+	# Dummy code
+	if teamSide = 2 && !isHelper {
+		if roundState = 0 {
+			# Round start reset
+			map(_iksys_trialsAirJumpNum) := 0;
+			map(_iksys_trialsButtonJam) := 0;
+			map(_iksys_trialsDirection) := 0;
+			map(_iksys_trialsDistance) := 0;
+			map(_iksys_trialsDummyControl) := 0;
+			map(_iksys_trialsDummyMode) := 0;
+			map(_iksys_trialsFallRecovery) := 0;
+			map(_iksys_trialsGuardMode) := 0;
+		}
+		if roundState = 2 {
+			# Dummy Control: Cooperative
+			if aiLevel = 0 && map(_iksys_trialsDummyControl) = 0 {
+				# Guard mode: Random
+				if map(_iksys_trialsGuardMode) = 3 {
+					if random < 500 {
+						assertSpecial{flag: autoGuard}
+					}
+				# Guard mode: All
+				} else if map(_iksys_trialsGuardMode) = 2 {
+					assertSpecial{flag: autoGuard}
+				# Guard mode: Auto
+				} else if map(_iksys_trialsGuardMode) = 1 {
+					if moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
+						map(_iksys_trialsAutoGuardTimer) := 15;
+					} else {
+						map(_iksys_trialsAutoGuardTimer) := (map(_iksys_trialsAutoGuardTimer) - 1);
+					}
+					if map(_iksys_trialsAutoGuardTimer) > 0 {
+						assertSpecial{flag: autoGuard}
+					}
+				}
+				# Fall Recovery
+				if map(_iksys_trialsFallRecovery) {
+					if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
+						if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
+							# Ground recovery. Attempt only if common1 conditions are met
+							if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold) {
+								if map(_iksys_trialsFallRecovery) = 1 { 
+									let rcv = 1;
+								}
+							# Air recovery. Attempt only if conditions for ground recovery are not met
+							} else if map(_iksys_trialsFallRecovery) = 2 {
+								let rcv = 1;
+							}
+							# Random recovery. Attempt regardless of conditions
+							if map(_iksys_trialsFallRecovery) = 3 && random < 100 {
+								let rcv = 1;
+							}
+							if $rcv {
+								# WinMugen characters assert inputs because asserting commands directly may trigger their AI activation codes
+								if mugenVersion < 1.0 {
+									if gametime % 2 {
+										assertInput{flag: x; flag2: y; flag3: z}
+									} else {
+										assertInput{flag: a; flag2: b; flag3: c}
+									}
+								} else {
+									assertCommand{name: "recovery"; buffer.time: 2}
+									# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
+								}
+								# Random direction
+								if map(_iksys_trialsFallRecovery) = 3 {
+									if random < 333 {
+										assertInput{flag: L}
+									} else if random < 500 {
+										assertInput{flag: R}
+									}
+									if random < 333 {
+										assertInput{flag: U}
+									} else if random < 500 {
+										assertInput{flag: D}
+									}
+								}
+							}
+						}
+					}
+				}
+				# Distance
+				let dir = 0;
+				if map(_iksys_trialsDistance) != 0 {
+					# Close
+					if map(_iksys_trialsDistance) = 1 {
+						if p2BodyDist x > const240p(10) {
+							let dir = 1;
+							map(_iksys_trialsDirection) := 1;
+						} else if p2BodyDist x < -(const(size.ground.front) + const(size.ground.back) + const240p(10)) {
+							let dir = -1;
+							map(_iksys_trialsDirection) := -1;
+						}
+					# Medium
+					} else if map(_iksys_trialsDistance) = 2 {
+						if p2BodyDist x > const240p(130) {
+							let dir = 1;
+							map(_iksys_trialsDirection) := 1;
+						} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
+							let dir = -1;
+							map(_iksys_trialsDirection) := -1;
+						}
+					# Far
+					} else if map(_iksys_trialsDistance) = 3 {
+						if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
+							let dir = -1;
+							map(_iksys_trialsDirection) := -1;
+						}
+					}
+				}
+				if map(_iksys_trialsDirection) != 0 {
+					# If adjusting position is no longer needed
+					if $dir = 0 {
+						# maintain assertion only if dummy and nearest P1 are moving in the same direction
+						if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
+							map(_iksys_trialsDirection) := 0;
+						}
+					}
+					# If dummy should move forward and player is not trying to move dummy manually
+					if map(_iksys_trialsDirection) = 1 {
+						if inputTime(B) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: F; redirectID: helperIndex($i), ID} # Index 0 being the root
+							}
+						}
+					# If dummy should move backward and player is not trying to move dummy manually
+					} else if map(_iksys_trialsDirection) = -1 {
+						if inputTime(F) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: B; redirectID: helperIndex($i), ID}
+							}
+						}
+					}
 				} else {
-					map(_iksys_trialsButtonJamDelay) := 11;
-					switch map(_iksys_trialsButtonJam) {
+					# Dummy mode
+					switch map(_iksys_trialsDummyMode) {
+					# Crouch
 					case 1:
-						assertInput{flag: a}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: a; redirectID: helperIndex($i), ID}
+						if inputTime(L) < 0 && inputTime(R) < 0 && inputTime(U) < 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: D; redirectID: helperIndex($i), ID}
 							}
 						}
+					# Jump
 					case 2:
-						assertInput{flag: b}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: b; redirectID: helperIndex($i), ID}
+						if inputTime(L) < 0 && inputTime(R) < 0 && inputTime(D) < 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: U; redirectID: helperIndex($i), ID}
 							}
 						}
+					# W Jump
 					case 3:
-						assertInput{flag: c}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: c; redirectID: helperIndex($i), ID}
-							}
-						}
-					case 4:
-						assertInput{flag: x}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: x; redirectID: helperIndex($i), ID}
-							}
-						}
-					case 5:
-						assertInput{flag: y}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: y; redirectID: helperIndex($i), ID}
-							}
-						}
-					case 6:
-						assertInput{flag: z}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: z; redirectID: helperIndex($i), ID}
-							}
-						}
-					case 7:
-						assertInput{flag: s}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: s; redirectID: helperIndex($i), ID}
-							}
-						}
-					case 8:
-						assertInput{flag: d}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: d; redirectID: helperIndex($i), ID}
-							}
-						}
-					case 9:
-						assertInput{flag: w}
-						if numHelper {
-							for i = 1; numHelper; 1 {
-								assertInput{flag: w; redirectID: helperIndex($i), ID}
+						if inputTime(L) < 0 && inputTime(R) < 0 && inputTime(D) < 0 {
+							if vel y >= 0 {
+								for i = 0; numHelper; 1 {
+									assertInput{flag: U; redirectID: helperIndex($i), ID}
+								}
 							}
 						}
 					default:
-						map(_iksys_trialsButtonJamDelay) := 0;
+						# Do nothing
+					}
+					# Button jam
+					if map(_iksys_trialsButtonJam) > 0 {
+						if map(_iksys_trialsButtonJamDelay) > 0 {
+							mapAdd{map: "_iksys_trialsButtonJamDelay"; value: -1}
+						} else {
+							map(_iksys_trialsButtonJamDelay) := 11;
+							switch map(_iksys_trialsButtonJam) {
+							case 1:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: a; redirectID: helperIndex($i), ID}
+								}
+							case 2:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: b; redirectID: helperIndex($i), ID}
+								}
+							case 3:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: c; redirectID: helperIndex($i), ID}
+								}
+							case 4:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: x; redirectID: helperIndex($i), ID}
+								}
+							case 5:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: y; redirectID: helperIndex($i), ID}
+								}
+							case 6:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: z; redirectID: helperIndex($i), ID}
+								}
+							case 7:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: s; redirectID: helperIndex($i), ID}
+								}
+							case 8:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: d; redirectID: helperIndex($i), ID}
+								}
+							case 9:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: w; redirectID: helperIndex($i), ID}
+								}
+							default:
+								map(_iksys_trialsButtonJamDelay) := 0;
+							}
+						}
 					}
 				}
+				if map(_iksys_trialsReposition) != 0 {
+					call TrialsReposition();
+					map(_iksys_trialsReposition) := 0;
+				}
+				if map(_iksys_trialsCameraReset) != 0 {
+					call TrialsResetCamera();
+					map(_iksys_trialsCameraReset) := 0;
+				}
 			}
-		}
-		if map(_iksys_trialsReposition) != 0 {
-			call TrialsReposition();
-			map(_iksys_trialsReposition) := 0;
-		}
-		if map(_iksys_trialsCameraReset) != 0 {
-			call TrialsResetCamera();
-			map(_iksys_trialsCameraReset) := 0;
 		}
 	}
 }

--- a/trials.zss
+++ b/trials.zss
@@ -16,8 +16,8 @@
 if player($pn),moveType = H || player($pn),dizzy {
 	mapSet{map: "_iksys_trialsLifeTimer"; value: 0; redirectid: player($pn),id}
 } else if player($pn),map(_iksys_trialsLifeTimer) >= 60 {
-	lifeSet{value: player($pn),lifeMax; redirectid: player($pn),id}
-	redLifeSet{value: player($pn),lifeMax; redirectid: player($pn),id}
+	lifeSet{value: player($pn),map(_iksys_trialsSetLife); redirectid: player($pn),id}
+	redLifeSet{value: player($pn),map(_iksys_trialsSetLife); redirectid: player($pn),id}
 	mapSet{map: "_iksys_trialsLifeTimer"; value: 0; redirectid: player($pn),id}
 } else {
 	mapAdd{map: "_iksys_trialsLifeTimer"; value: 1; redirectid: player($pn),id}

--- a/trials.zss
+++ b/trials.zss
@@ -6,7 +6,8 @@
 # _iksys_trialsDummyMode: 0 - stand, 1 - crouch, 2 - jump, 3 - wjump
 # _iksys_trialsDistance: 0 - any, 1 - close, 2 - medium, 3 - far
 # _iksys_trialsButtonJam: 0 - none, 1-9 - a/b/c/x/y/z/s/d/w
-# _iksys_trialsPosX: value: 
+# _iksys_trialsInitPosX: value: 
+# _iksys_trialsInitPosY: value: 
 
 #===============================================================================
 # Functions
@@ -14,8 +15,8 @@
 [Function TrialsInitialPosition()]
 # Get initial positions
 for pn = 1; 2; 1 {
-	mapSet{map:"_iksys_trialsPosX"; value: player($pn),Pos x; redirectID: player($pn),id;}
-	mapSet{map:"_iksys_trialsPosY"; value: player($pn),Pos y; redirectID: player($pn),id;}
+	mapSet{map:"_iksys_trialsInitPosX"; value: player($pn),Pos x; redirectID: player($pn),id;}
+	mapSet{map:"_iksys_trialsInitPosY"; value: player($pn),Pos y; redirectID: player($pn),id;}
 	mapSet{map:"_iksys_trialsCameraPosX"; value: player($pn),CameraPos x; redirectID: player($pn),id;}
 	mapSet{map:"_iksys_trialsCameraPosY"; value: player($pn),CameraPos y; redirectID: player($pn),id;}
 	mapSet{map:"_iksys_trialsScreenPosX"; value: player($pn),ScreenPos x; redirectID: player($pn),id;}
@@ -25,8 +26,14 @@ for pn = 1; 2; 1 {
 [Function TrialsReposition()]
 Camera{view: free; pos:0,0;}
 for pn = 1; 2; 1 {
-	if player($pn), map(_iksys_trialsPosX) != 0 {PosSet{x:player($pn), map(_iksys_trialsPosX); y:player($pn), map(_iksys_trialsPosY); redirectID: player($pn),id;}}
+	if player($pn), map(_iksys_trialsInitPosX) != 0 {
+		PosSet{x:player($pn), map(_iksys_trialsInitPosX); y:player($pn), map(_iksys_trialsInitPosY); redirectID: player($pn),id;}
+	}
 }
+# if map(_iksys_trialsInitPosX) != 0 {
+# 	PosSet{x: player(1), map(_iksys_trialsInitPosX); y:player(1) , map(_iksys_trialsInitPosY); redirectID: player(1),id;}
+# 	PosSet{x: player(2), map(_iksys_trialsInitPosX); y:player(2) , map(_iksys_trialsInitPosY); redirectID: player(2),id;}
+# }
 
 [Function TrialsResetCamera()]
 Camera{view: fighting}

--- a/trials.zss
+++ b/trials.zss
@@ -14,10 +14,6 @@
 #===============================================================================
 [Function TrialsReposition()]
 if map(_iksys_trialsReposition) != 0 {
-	PrintToConsole{
-		text: "player1posx: %f, dummyposx: %f";
-		params: map(_iksys_trialsPlayerPosX), map(_iksys_trialsDummyPosX);
-	}
 	Camera{
 		view: free; 
 		pos: map(_iksys_trialsCameraPosX), (map(_iksys_trialsPlayerPosY) + map(_iksys_trialsDummyPosY))/2;
@@ -107,11 +103,6 @@ ignoreHitPause if gameMode = "trials" {
 			map(_iksys_trialsGuardMode) := 0;
 		}
 		if roundState = 2 {
-			# PrintToConsole{
-			# 	text: "p1posX = %f, p2posX = %f";
-			# 	params: player(1), pos x, player(2), pos x;
-			# }
-
 			# Dummy Control: Cooperative
 			if aiLevel = 0 && map(_iksys_trialsDummyControl) = 0 {
 				# Guard mode: Random

--- a/trials.zss
+++ b/trials.zss
@@ -12,28 +12,28 @@
 #===============================================================================
 # Functions
 #===============================================================================
-[Function TrialsInitialPosition()]
-# Get initial positions
-for pn = 1; 2; 1 {
-	mapSet{map:"_iksys_trialsInitPosX"; value: player($pn),Pos x; redirectID: player($pn),id;}
-	mapSet{map:"_iksys_trialsInitPosY"; value: player($pn),Pos y; redirectID: player($pn),id;}
-	mapSet{map:"_iksys_trialsCameraPosX"; value: player($pn),CameraPos x; redirectID: player($pn),id;}
-	mapSet{map:"_iksys_trialsCameraPosY"; value: player($pn),CameraPos y; redirectID: player($pn),id;}
-	mapSet{map:"_iksys_trialsScreenPosX"; value: player($pn),ScreenPos x; redirectID: player($pn),id;}
-	mapSet{map:"_iksys_trialsScreenPosY"; value: player($pn),ScreenPos y; redirectID: player($pn),id;}
-}
+# [Function TrialsInitialPosition()]
+# # Get initial positions
+# for pn = 1; 2; 1 {
+# 	mapSet{map:"_iksys_trialsInitPosX"; value: player($pn),Pos x; redirectID: player($pn),id;}
+# 	mapSet{map:"_iksys_trialsInitPosY"; value: player($pn),Pos y; redirectID: player($pn),id;}
+# 	mapSet{map:"_iksys_trialsCameraPosX"; value: player($pn),CameraPos x; redirectID: player($pn),id;}
+# 	mapSet{map:"_iksys_trialsCameraPosY"; value: player($pn),CameraPos y; redirectID: player($pn),id;}
+# 	mapSet{map:"_iksys_trialsScreenPosX"; value: player($pn),ScreenPos x; redirectID: player($pn),id;}
+# 	mapSet{map:"_iksys_trialsScreenPosY"; value: player($pn),ScreenPos y; redirectID: player($pn),id;}
+# }
 
 [Function TrialsReposition()]
 Camera{view: free; pos:0,0;}
-for pn = 1; 2; 1 {
-	if player($pn), map(_iksys_trialsInitPosX) != 0 {
-		PosSet{x:player($pn), map(_iksys_trialsInitPosX); y:player($pn), map(_iksys_trialsInitPosY); redirectID: player($pn),id;}
-	}
-}
-# if map(_iksys_trialsInitPosX) != 0 {
-# 	PosSet{x: player(1), map(_iksys_trialsInitPosX); y:player(1) , map(_iksys_trialsInitPosY); redirectID: player(1),id;}
-# 	PosSet{x: player(2), map(_iksys_trialsInitPosX); y:player(2) , map(_iksys_trialsInitPosY); redirectID: player(2),id;}
+# for pn = 1; 2; 1 {
+# 	if player($pn), map(_iksys_trialsInitPosX) != 0 {
+# 		PosSet{x:player($pn), map(_iksys_trialsInitPosX); y:player($pn), map(_iksys_trialsInitPosY); redirectID: player($pn),id;}
+# 	}
 # }
+if map(_iksys_trialsReposition) != 0 {
+	PosSet{x: player(1), map(_iksys_trialsPlayerPosX); y: player(1), map(_iksys_trialsPlayerPosY); redirectID: player(1),id;}
+	PosSet{x: player(2), map(_iksys_trialsDummyPosX); y: player(2), map(_iksys_trialsDummyPosY); redirectID: player(2),id;}
+}
 
 [Function TrialsResetCamera()]
 Camera{view: fighting}
@@ -50,7 +50,7 @@ ignoreHitPause if gameMode = "trials" {
 		map(_iksys_trialsLifeTimer) := 0;
 		map(_iksys_trialsPowerTimer) := 0;
 		map(_iksys_trialsReposition) := 0;
-		call TrialsInitialPosition();
+		# call TrialsInitialPosition();
 	}
 	# Life and Power recovery
 	if !isHelper {

--- a/trials.zss
+++ b/trials.zss
@@ -20,7 +20,7 @@ if map(_iksys_trialsReposition) != 0 {
 	}
 	Camera{
 		view: free; 
-		pos: (map(_iksys_trialsPlayerPosX) + map(_iksys_trialsDummyPosX))/2, (map(_iksys_trialsPlayerPosY) + map(_iksys_trialsDummyPosY))/2;
+		pos: map(_iksys_trialsCameraPosX), (map(_iksys_trialsPlayerPosY) + map(_iksys_trialsDummyPosY))/2;
 	}
 	PosSet{
 		x: map(_iksys_trialsPlayerPosX); 
@@ -107,6 +107,11 @@ ignoreHitPause if gameMode = "trials" {
 			map(_iksys_trialsGuardMode) := 0;
 		}
 		if roundState = 2 {
+			# PrintToConsole{
+			# 	text: "p1posX = %f, p2posX = %f";
+			# 	params: player(1), pos x, player(2), pos x;
+			# }
+
 			# Dummy Control: Cooperative
 			if aiLevel = 0 && map(_iksys_trialsDummyControl) = 0 {
 				# Guard mode: Random


### PR DESCRIPTION
- Introduces multilingual support for:
  - `trial.textbox`
  - `trialstep.X.text`
- Fixes a bug where any trial with `trialstep.X.hitcount = 0` did not register
- Fixes a box where if one `trial.textbox` was created, all other trials would have a textbox that said `nil`.
- Fixes a bug introduced in 10-10-25 Nightly re: localcoord
  - This release will only be compatible with latest nightly Ikemen GO build.
- Introduces `trial.p1life` and `trial.p2life` as a way of setting P1 and P2's life for a trial.
  - This is particularly useful for characters that have access to special moves or features with low life totals, or to demonstrate the damage potential of certain combos.
- Introduces `trial.dummypos` and `trial.playerpos` to optionally place the dummy or player on the stage. Valid arguments are:
  - `left-corner`
  - `right-corner`
  - `close`
  - `medium`
  - `far`
  - Behavior/defaults will be detailed in Wiki entry.
  - Also introduces the ability to reset positioning on stage by pressing d+w simultaneously (will try to make this configurable).